### PR TITLE
Fixed ComputeRosterType to correctly handle unassigned players

### DIFF
--- a/GenOnlineService/Database/Database.MatchHistory.cs
+++ b/GenOnlineService/Database/Database.MatchHistory.cs
@@ -413,7 +413,7 @@ namespace Database
 
 			int activePlayers = groups.Sum();
 
-			if (activePlayers == 0)
+			if (activePlayers == 0 || groups.Count == 1)
 			{
 				return "Unknown";
 			}

--- a/GenOnlineService/Database/Database.MatchHistory.cs
+++ b/GenOnlineService/Database/Database.MatchHistory.cs
@@ -402,30 +402,28 @@ namespace Database
 
 		private static string ComputeRosterType(Dictionary<int, int> playersPerTeam)
 		{
-			int noTeamCount = playersPerTeam.TryGetValue(-1, out int n) ? n : 0;
+			int noTeamCount = playersPerTeam.GetValueOrDefault(-1, 0);
 
-			var teamedGroups = playersPerTeam
+			var groups = playersPerTeam
 				.Where(kv => kv.Key != -1)
 				.Select(kv => kv.Value)
+				.Concat(Enumerable.Repeat(1, noTeamCount))
 				.OrderBy(c => c)
 				.ToList();
 
-			int activePlayers = noTeamCount + teamedGroups.Sum();
+			int activePlayers = groups.Sum();
 
 			if (activePlayers == 0)
 			{
 				return "Unknown";
 			}
 
-			bool isFFA = activePlayers > 2 &&
-						 (noTeamCount == activePlayers || teamedGroups.All(c => c == 1));
-
-			if (isFFA)
+			if (activePlayers > 2 && groups.All(c => c == 1))
 			{
 				return $"{activePlayers} Player FFA";
 			}
 
-			return string.Join("v", teamedGroups);
+			return string.Join("v", groups);
 		}
 
 


### PR DESCRIPTION
- Fixed an issue where matches consisting only of unassigned players (`team -1`) would result in empty strings (e.g. 1v1s).
- Updated grouping logic to append unassigned players as individual groups of 1 using `Enumerable.Repeat`, eliminating the standalone FFA check.
- Updated to return "Unknown" for matches where all active players are on the same team (`groups.Count == 1`).
