### PR TITLE
feat(session): Add platform identification for macOS users

### DIFF
--- a/GenOnlineService/Constants.cs
+++ b/GenOnlineService/Constants.cs
@@ -48,16 +48,18 @@ namespace GenOnlineService
 	}
 	public class RoomMember
 	{
-		public RoomMember(Int64 a_UserID, string strName, bool admin)
+		public RoomMember(Int64 a_UserID, string strName, bool admin, string platform)
 		{
 			UserID = a_UserID;
 			Name = strName;
 			IsAdmin = admin;
+			Platform = platform;
 		}
 
 		public Int64 UserID { get; set; } = -1;
 		public String Name { get; set; } = String.Empty;
 		public bool IsAdmin { get; set; } = false;
+		public String Platform { get; set; } = Platforms.Unknown;
 	}
 
 	public enum EPendingLoginState
@@ -188,13 +190,45 @@ namespace GenOnlineService
 		};
 	}
 
+	// The platform is self-reported by the client and echoed back to every other
+	// member of a lobby, so it is clamped to a known set rather than passed through.
+	public static class Platforms
+	{
+		public const string Unknown = "unknown";
+		public const string Windows = "windows";
+		public const string MacOS = "macos";
+
+		private static readonly HashSet<string> Known = new(StringComparer.OrdinalIgnoreCase)
+		{
+			Windows,
+			MacOS
+		};
+
+		public static string Normalize(string? platform)
+		{
+			if (String.IsNullOrWhiteSpace(platform))
+			{
+				return Unknown;
+			}
+
+			string trimmed = platform.Trim();
+
+			if (!Known.Contains(trimmed))
+			{
+				return Unknown;
+			}
+
+			return trimmed.ToLowerInvariant();
+		}
+	}
+
 
 
 	// TODO
 	static class WebSocketManager
 	{
 		public static int g_PeakConnectionCount = 0;
-		public static async Task<UserWebSocketInstance> CreateSession(AppDbContext _db, EUserSessionType sessionType, bool bIsReconnect, Int64 ownerID, KnownClients.EKnownClients client_id, string ipAddr, string strContinent, string strCountry, double dLatitude, double dLongitude, bool bIsAdmin)
+		public static async Task<UserWebSocketInstance> CreateSession(AppDbContext _db, EUserSessionType sessionType, bool bIsReconnect, Int64 ownerID, KnownClients.EKnownClients client_id, string ipAddr, string strContinent, string strCountry, double dLatitude, double dLongitude, bool bIsAdmin, string platform)
 		{
 			string strDisplayName = await Database.Users.GetDisplayName(_db, ownerID);
 
@@ -266,7 +300,7 @@ namespace GenOnlineService
 				// get stats
 				PlayerStats GameStats = await Database.UserStats.GetPlayerStats(_db, ownerID);
 
-				userCacheData = new UserSession(ownerID, sessionType, client_id, strContinent, strCountry, dLatitude, dLongitude);
+				userCacheData = new UserSession(ownerID, sessionType, client_id, strContinent, strCountry, dLatitude, dLongitude, platform);
 				m_dictUserSessions[sessionType][ownerID] = userCacheData;
 				
 				// TODO_SOCIAL: Move this to a class
@@ -781,7 +815,7 @@ namespace GenOnlineService
 									}
 									
 
-									memberListUpdate.members.Add(new RoomMember(sess.m_UserID, strDisplayName, sharedUserData.IsAdmin()));
+									memberListUpdate.members.Add(new RoomMember(sess.m_UserID, strDisplayName, sharedUserData.IsAdmin(), sess.Platform));
 
 									// also add to list of users who need this update, since they were in there
 									lstUsersToSend.Add(sess.m_UserID);
@@ -899,6 +933,7 @@ namespace GenOnlineService
 		private string m_strMiddlewareUserID = String.Empty;
 
 		public KnownClients.EKnownClients m_client_id = KnownClients.EKnownClients.unknown;
+		public string Platform { get; private set; } = Platforms.Unknown;
 		DateTime m_CreateTime = DateTime.Now;
 		public DateTime GetCreationTime()
 		{
@@ -936,7 +971,7 @@ namespace GenOnlineService
 			return DateTime.Now - m_CreateTime;
 		}
 
-		public UserSession(Int64 ownerID, EUserSessionType sessionType, KnownClients.EKnownClients client_id, string strContinent, string strCountry, double dLatitude, double dLongitude)
+		public UserSession(Int64 ownerID, EUserSessionType sessionType, KnownClients.EKnownClients client_id, string strContinent, string strCountry, double dLatitude, double dLongitude, string platform)
 		{
 			m_sessionType = sessionType;
 			m_client_id = client_id;
@@ -944,6 +979,7 @@ namespace GenOnlineService
 			m_strCountry = strCountry;
 			m_dLatitude = dLatitude;
 			m_dLongitude = dLongitude;
+			Platform = platform;
 
 			m_UserID = ownerID;
 

--- a/GenOnlineService/Controllers/CheckLogin/CheckLoginController.cs
+++ b/GenOnlineService/Controllers/CheckLogin/CheckLoginController.cs
@@ -207,8 +207,10 @@ namespace GenOnlineService.Controllers
 											string exe_crc = data.ContainsKey("exe_crc") ? data["exe_crc"].ToString() : "NONE";
 											Helpers.RegisterInitialPlayerExeCRC(user_id, exe_crc);
 
-											var sessiontoken = Program.g_tokenGenerator.GenerateToken(strDisplayName, user_id, ipAddr, Program.JwtTokenGenerator.ETokenType.Session, knownClientID, sessionType, bIsAdmin);
-											var refreshtoken = Program.g_tokenGenerator.GenerateToken(strDisplayName, user_id, ipAddr, Program.JwtTokenGenerator.ETokenType.Refresh, knownClientID, sessionType, false, out string refreshJti);
+											string platform = data.ContainsKey("platform") ? data["platform"].ToString() : Platforms.Unknown;
+
+											var sessiontoken = Program.g_tokenGenerator.GenerateToken(strDisplayName, user_id, ipAddr, Program.JwtTokenGenerator.ETokenType.Session, knownClientID, sessionType, bIsAdmin, platform);
+											var refreshtoken = Program.g_tokenGenerator.GenerateToken(strDisplayName, user_id, ipAddr, Program.JwtTokenGenerator.ETokenType.Refresh, knownClientID, sessionType, false, platform, out string refreshJti);
 
 											// rotation: only this refresh token is accepted from now on
 											await TokenRevocationManager.OnTokensIssued(user_id, sessionType, refreshJti);

--- a/GenOnlineService/Controllers/LoginWithToken/LoginWithTokenController.cs
+++ b/GenOnlineService/Controllers/LoginWithToken/LoginWithTokenController.cs
@@ -143,6 +143,8 @@ namespace GenOnlineService.Controllers.LoginWithToken
 						string exe_crc = data.ContainsKey("exe_crc") ? data["exe_crc"].ToString() : "NONE";
 						Helpers.RegisterInitialPlayerExeCRC(user_id, exe_crc);
 
+						string platform = data.ContainsKey("platform") ? data["platform"].ToString() : Platforms.Unknown;
+
 						string strDisplayName = await Database.Users.GetDisplayName(db, user_id);
 						await SessionHelpers.SetUsedLoggedIn(user_id, clientID, sessionType);
 
@@ -152,8 +154,8 @@ namespace GenOnlineService.Controllers.LoginWithToken
 
 						// extend token
 						// TODO_TODAY_JWT: just get clientID from token
-						var sessiontoken = Program.g_tokenGenerator.GenerateToken(strDisplayName, user_id, ipAddr, Program.JwtTokenGenerator.ETokenType.Session, clientID, sessionType, bIsAdmin);
-						var refreshtoken = Program.g_tokenGenerator.GenerateToken(strDisplayName, user_id, ipAddr, Program.JwtTokenGenerator.ETokenType.Refresh, clientID, sessionType, false, out string refreshJti);
+						var sessiontoken = Program.g_tokenGenerator.GenerateToken(strDisplayName, user_id, ipAddr, Program.JwtTokenGenerator.ETokenType.Session, clientID, sessionType, bIsAdmin, platform);
+						var refreshtoken = Program.g_tokenGenerator.GenerateToken(strDisplayName, user_id, ipAddr, Program.JwtTokenGenerator.ETokenType.Refresh, clientID, sessionType, false, platform, out string refreshJti);
 
 						// rotation: only this refresh token is accepted from now on
 						await TokenRevocationManager.OnTokensIssued(user_id, sessionType, refreshJti);

--- a/GenOnlineService/Controllers/RefreshToken/RefreshTokenController.cs
+++ b/GenOnlineService/Controllers/RefreshToken/RefreshTokenController.cs
@@ -111,8 +111,11 @@ namespace GenOnlineService.Controllers.RefreshToken
 				string strDisplayName = await Database.Users.GetDisplayName(db, user_id);
 				bool bIsAdmin = await Database.Users.IsUserAdmin(db, user_id);
 
-				var sessiontoken = Program.g_tokenGenerator.GenerateToken(strDisplayName, user_id, ipAddr, Program.JwtTokenGenerator.ETokenType.Session, clientID, sessionType, bIsAdmin);
-				var refreshtoken = Program.g_tokenGenerator.GenerateToken(strDisplayName, user_id, ipAddr, Program.JwtTokenGenerator.ETokenType.Refresh, clientID, sessionType, false, out string refreshJti);
+				// carried over from the token being rotated, so the platform survives a refresh
+				string platform = TokenHelper.GetPlatform(this);
+
+				var sessiontoken = Program.g_tokenGenerator.GenerateToken(strDisplayName, user_id, ipAddr, Program.JwtTokenGenerator.ETokenType.Session, clientID, sessionType, bIsAdmin, platform);
+				var refreshtoken = Program.g_tokenGenerator.GenerateToken(strDisplayName, user_id, ipAddr, Program.JwtTokenGenerator.ETokenType.Refresh, clientID, sessionType, false, platform, out string refreshJti);
 
 				// rotation: only this refresh token is accepted from now on
 				await TokenRevocationManager.OnTokensIssued(user_id, sessionType, refreshJti);

--- a/GenOnlineService/Controllers/WebSocket/WebSocketController.cs
+++ b/GenOnlineService/Controllers/WebSocket/WebSocketController.cs
@@ -144,6 +144,7 @@ namespace GenOnlineService.Controllers
 			}
 
 			EUserSessionType sessType = TokenHelper.GetSessionType(this);
+			string platform = TokenHelper.GetPlatform(this);
 
 			await using var db = await _dbFactory.CreateDbContextAsync();
 			UserWebSocketInstance wsSess = await WebSocketManager.CreateSession(
@@ -157,7 +158,8 @@ namespace GenOnlineService.Controllers
 				ipCountry,
 				dLatitude,
 				dLongitude,
-				bIsAdmin);
+				bIsAdmin,
+				platform);
 
 			// if null, it was probably a reconnect and they need to fully reconnect, so return an error instead
 			if (wsSess == null)

--- a/GenOnlineService/LobbyManager.cs
+++ b/GenOnlineService/LobbyManager.cs
@@ -1298,6 +1298,7 @@ public async Task FinalizeACChecks()
 		public EPlayerType SlotState { get; private set; } = 0;
 		public UInt16 SlotIndex { get; private set; } = 0;
 		public string Region { get; private set; } = "Unknown";
+		public string Platform { get; private set; } = Platforms.Unknown;
 		public string MiddlewareUserID { get; private set; } = String.Empty;
 
 		[JsonIgnore] // cant serialize refs
@@ -1339,6 +1340,7 @@ public async Task FinalizeACChecks()
 
 			IsReady = false;
 			Region = owningSession == null ? "Unknown" : owningSession.GetFullContinentName();
+			Platform = owningSession == null ? Platforms.Unknown : owningSession.Platform;
 		}
 
 		public bool IsHuman() {  return SlotState == EPlayerType.SLOT_PLAYER; }

--- a/GenOnlineService/Program.cs
+++ b/GenOnlineService/Program.cs
@@ -392,6 +392,16 @@ namespace GenOnlineService
 			return EUserSessionType.None;
 		}
 
+		public static string GetPlatform(ControllerBase controller)
+		{
+			var first = controller.User.FindFirst(Program.JwtTokenGenerator.PlatformClaim);
+
+			if (first == null)
+				return Platforms.Unknown;
+
+			return Platforms.Normalize(first.Value);
+		}
+
 		public static string GetDisplayName(ControllerBase controller)
 		{
 			// TODO: Handle not finding claims, it is a critical error
@@ -710,13 +720,14 @@ namespace GenOnlineService
 			}
 
 			public const string TokenGenerationClaim = "tgen";
+			public const string PlatformClaim = "platform";
 
-			public string GenerateToken(string displayname, Int64 userID, string ipAddr, ETokenType tokenType, KnownClients.EKnownClients knownClientID, EUserSessionType sessionType, bool bIsAdmin)
+			public string GenerateToken(string displayname, Int64 userID, string ipAddr, ETokenType tokenType, KnownClients.EKnownClients knownClientID, EUserSessionType sessionType, bool bIsAdmin, string platform)
 			{
-				return GenerateToken(displayname, userID, ipAddr, tokenType, knownClientID, sessionType, bIsAdmin, out _);
+				return GenerateToken(displayname, userID, ipAddr, tokenType, knownClientID, sessionType, bIsAdmin, platform, out _);
 			}
 
-			public string GenerateToken(string displayname, Int64 userID, string ipAddr, ETokenType tokenType, KnownClients.EKnownClients knownClientID, EUserSessionType sessionType, bool bIsAdmin, out string jti)
+			public string GenerateToken(string displayname, Int64 userID, string ipAddr, ETokenType tokenType, KnownClients.EKnownClients knownClientID, EUserSessionType sessionType, bool bIsAdmin, string platform, out string jti)
 			{
 				var jwtSettings = _configuration.GetSection("JwtSettings");
 
@@ -745,6 +756,7 @@ namespace GenOnlineService
 					new Claim(JwtRegisteredClaimNames.Typ, ((int)tokenType).ToString()),
 					new Claim("client_id", ((int)knownClientID).ToString()),
 					new Claim("session_type", ((int)sessionType).ToString()),
+					new Claim(PlatformClaim, Platforms.Normalize(platform)),
 
 					// Token generation, checked against the revocation manager on every request so
 					// that bans/logouts can invalidate tokens before they naturally expire.


### PR DESCRIPTION
Players asked to display a platform indicator (Mac/Windows) in the game client so they can see who is playing on what system, since we haven't made CRC compatibility between win and mac yet. Having a platform flag is also generally useful for future service development.

Propagated the `platform` field from the login/token request bodies to `UserSession`, `RoomMember`, and `LobbyMember`. This exposes the platform info to the client so it can render the platform icon/status.
