### PR TITLE
fix(stats): report correctly resolved side instead of random in custom matches

### DIFF
--- a/GenOnlineService/Controllers/Lobby/LobbyController.cs
+++ b/GenOnlineService/Controllers/Lobby/LobbyController.cs
@@ -302,6 +302,7 @@ namespace GenOnlineService.Controllers
 						&& data.ContainsKey("units_lost")
 						&& data.ContainsKey("total_money")
 						&& data.ContainsKey("won")
+						&& data.ContainsKey("side")
 						)
 					{
 						Int64 user_id = TokenHelper.GetUserID(this);
@@ -318,6 +319,7 @@ namespace GenOnlineService.Controllers
 								int units_killed = data["units_killed"].GetInt32();
 								int units_lost = data["units_lost"].GetInt32();
 								int total_money = data["total_money"].GetInt32();
+								int side = data["side"].GetInt32();
 								bool won = data["won"].GetBoolean();
 								UInt64 match_id = data["match_id"].GetUInt64();
 
@@ -337,7 +339,7 @@ namespace GenOnlineService.Controllers
 
 								// store in DB
 								await using var db = await _dbFactory.CreateDbContextAsync();
-								await Database.MatchHistory.CommitPlayerOutcome(db, slotIndexInLobby, match_id,
+								await Database.MatchHistory.CommitPlayerOutcome(db, slotIndexInLobby, match_id, side,
 										buildings_built, buildings_killed, buildings_lost, units_built, units_killed, units_lost, total_money, won);
 							}
 						}

--- a/GenOnlineService/Database/Database.MatchHistory.cs
+++ b/GenOnlineService/Database/Database.MatchHistory.cs
@@ -331,6 +331,7 @@ namespace Database
 	AppDbContext db,
 	int slotIndex,
 	ulong matchId,
+	int side,
 	int buildingsBuilt,
 	int buildingsKilled,
 	int buildingsLost,
@@ -357,6 +358,7 @@ namespace Database
 
 				// 3. Update fields
 				MatchdataMemberModel model = modelNullable.Value;
+				model.side = side;
 				model.buildings_built = buildingsBuilt;
 				model.buildings_killed = buildingsKilled;
 				model.buildings_lost = buildingsLost;


### PR DESCRIPTION
The player's side was previously persisted to the database when `Database.MatchHistory.CreatePlaceholderMatchHistory(db, lobby)` was called at the start of the match.

This was not an issue for quickmatch games because the player's side had already been resolved and assigned during lobby creation. For custom matches, however, the side was still `PLAYERTEMPLATE_RANDOM` at that point, so the placeholder match history persisted the unresolved value.

This change records the player's resolved side in `Database.MatchHistory.CommitPlayerOutcome`, overriding the placeholder value in the database. By that point, `PLAYERTEMPLATE_RANDOM` has been replaced with the actual resolved faction in `PlayerTemplate`, allowing the correct side to be persisted.

Merge alongside https://github.com/GeneralsOnlineDevelopmentTeam/GameClient/pull/520 (`fix(stats): pass resolved side in game outcome payload`