### PR TITLE
Handle unmapped client IDs and respect disabled match uploads

### DIFF
--- a/GenOnlineService/Constants.cs
+++ b/GenOnlineService/Constants.cs
@@ -2029,9 +2029,24 @@ namespace GenOnlineService
 	public static class S3CredentialManager
 	{
 		private static AmazonS3Client m_s3client = null;
+		private static bool s_uploadsEnabled = false;
 
 		public static void Initialize()
 		{
+			if (Program.g_Config == null)
+			{
+				throw new Exception("Config not loaded");
+			}
+
+			s_uploadsEnabled = Program.g_Config.GetSection("MatchData").GetValue<bool?>("upload_match_data") ?? false;
+
+			// When uploads are disabled, the S3 settings are intentionally optional.
+			if (!s_uploadsEnabled)
+			{
+				Console.WriteLine("MatchData: upload_match_data is false, replay and screenshot uploads are disabled.");
+				return;
+			}
+
 			GetS3Config(out int TTL, out string access_key, out string secret_key, out string bucket_name, out string client_endpoint);
 
 			var config = new AmazonS3Config
@@ -2103,6 +2118,11 @@ namespace GenOnlineService
 
 		public static async Task<string?> GetPresignedURL(EMetadataFileType fileType, EScreenshotType screenshotTypeIfScreenshot, UInt64 matchID, Int64 userID, int slotIndex, DateTime matchStartTime)
 		{
+			if (!s_uploadsEnabled || m_s3client == null)
+			{
+				return null;
+			}
+
 			GetS3Config(out int TTL, out string access_key, out string secret_key, out string bucket_name, out string client_endpoint);
 			TimeSpan expiresIn = TimeSpan.FromMinutes(TTL);
 

--- a/GenOnlineService/Controllers/CheckLogin/CheckLoginController.cs
+++ b/GenOnlineService/Controllers/CheckLogin/CheckLoginController.cs
@@ -189,11 +189,10 @@ namespace GenOnlineService.Controllers
 									}
 
 									// full login (known clients)
-									if (Enum.TryParse(typeof(KnownClients.EKnownClients), clientID, ignoreCase: true, out object knownClientIDObj))
+									// Enum.TryParse also accepts "unknown" and arbitrary numeric strings, neither of which is mapped.
+									if (Enum.TryParse(clientID, ignoreCase: true, out KnownClients.EKnownClients knownClientID)
+										&& KnownClients.KnownClientSessionTypes.TryGetValue(knownClientID, out EUserSessionType sessionType))
 									{
-										KnownClients.EKnownClients knownClientID = (KnownClients.EKnownClients)knownClientIDObj;
-										EUserSessionType sessionType = KnownClients.KnownClientSessionTypes[knownClientID];
-
 										// Game clients should register the user device
 										if (sessionType == EUserSessionType.GameClient)
 										{

--- a/GenOnlineService/Controllers/Lobby/LobbyController.cs
+++ b/GenOnlineService/Controllers/Lobby/LobbyController.cs
@@ -334,8 +334,8 @@ namespace GenOnlineService.Controllers
 								DailyStatsManager.RegisterOutcome(army, won);
 
 								// give them back signed URLs they need
-								result.screenshot_url = await S3CredentialManager.GetPresignedURL(EMetadataFileType.FILE_TYPE_SCREENSHOT, EScreenshotType.SCREENSHOT_TYPE_SCORESCREEN, match_id, user_id, slotIndexInLobby, LobbyCreationTime);
-								result.replay_url = await S3CredentialManager.GetPresignedURL(EMetadataFileType.FILE_TYPE_REPLAY, EScreenshotType.NONE, match_id, user_id, slotIndexInLobby, LobbyCreationTime);
+								result.screenshot_url = await S3CredentialManager.GetPresignedURL(EMetadataFileType.FILE_TYPE_SCREENSHOT, EScreenshotType.SCREENSHOT_TYPE_SCORESCREEN, match_id, user_id, slotIndexInLobby, LobbyCreationTime) ?? String.Empty;
+								result.replay_url = await S3CredentialManager.GetPresignedURL(EMetadataFileType.FILE_TYPE_REPLAY, EScreenshotType.NONE, match_id, user_id, slotIndexInLobby, LobbyCreationTime) ?? String.Empty;
 
 								// store in DB
 								await using var db = await _dbFactory.CreateDbContextAsync();

--- a/GenOnlineService/Controllers/WebSocket/WebSocketController.cs
+++ b/GenOnlineService/Controllers/WebSocket/WebSocketController.cs
@@ -758,7 +758,7 @@ namespace GenOnlineService.Controllers
 									// response
 									WebSocketMessage_StartMatch startCommand = new WebSocketMessage_StartMatch();
 									startCommand.msg_id = (int)EWebSocketMessageID.START_GAME;
-									startCommand.screenshot_url = await S3CredentialManager.GetPresignedURL(EMetadataFileType.FILE_TYPE_SCREENSHOT, EScreenshotType.SCREENSHOT_TYPE_LOADSCREEN, lobbyInfo.MatchID, lobbyMember.UserID, lobbyMember.SlotIndex, lobbyInfo.TimeCreated);
+									startCommand.screenshot_url = await S3CredentialManager.GetPresignedURL(EMetadataFileType.FILE_TYPE_SCREENSHOT, EScreenshotType.SCREENSHOT_TYPE_LOADSCREEN, lobbyInfo.MatchID, lobbyMember.UserID, lobbyMember.SlotIndex, lobbyInfo.TimeCreated) ?? String.Empty;
 
 									// Serialize once before broadcasting
 									byte[] bytesJSON = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(startCommand));


### PR DESCRIPTION
- Handle enum-compatible but unmapped client IDs without returning HTTP 500.
- Respect `MatchData.upload_match_data` before initializing the S3 client.
- Skip presigned URL generation when match uploads are disabled.
- Return empty upload URLs in lobby and WebSocket responses when uploads are unavailable.

---

`Enum.TryParse` accepts values such as `unknown` and arbitrary numeric values. These values were not present in the known-client session mapping, causing the login request to return HTTP 500.

The match-data upload toggle was also not honored during S3 initialization or URL generation. Disabling uploads still required valid S3 configuration and attempted to generate upload URLs.