### PR TITLE
Enforce the 200 friend limit on both users and await request acceptance

### DIFF
--- a/GenOnlineService/Controllers/Friends/SocialController.cs
+++ b/GenOnlineService/Controllers/Friends/SocialController.cs
@@ -67,6 +67,8 @@ namespace GenOnlineService.Controllers
 	[Route("env/{environment}/contract/{contract_version}/[controller]")]
 	public class SocialController : ControllerBase
 	{
+		private const int FriendsLimit = 200;
+
 		private readonly IDbContextFactory<AppDbContext> _dbFactory;
 		private readonly ILogger<SocialController> _logger;
 
@@ -81,18 +83,47 @@ namespace GenOnlineService.Controllers
 		// POST = accept request
 		// DELETE = reject request
 
-		private async Task HelperFunction_AcceptFriendRequest(Int64 source_user_id, Int64 target_user_id)
+		private bool RejectIfFriendsListFull(Int64 user_id, SharedUserData userData)
 		{
+			if (userData.GetSocialContainer().Friends.Count < FriendsLimit)
+			{
+				return false;
+			}
+
+			WebSocketMessage_Social_FriendsListFull friendsListFullEvent = new();
+			friendsListFullEvent.msg_id = (int)EWebSocketMessageID.SOCIAL_CANT_ADD_FRIEND_LIST_FULL;
+			byte[] bytesJSON = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(friendsListFullEvent));
+
+			WebsocketHelper.SendToAllSessionsOfUser(user_id, bytesJSON);
+			Response.StatusCode = (int)HttpStatusCode.Forbidden;
+			return true;
+		}
+
+		private async Task<bool> HelperFunction_AcceptFriendRequest(Int64 source_user_id, Int64 target_user_id)
+		{
+			// NOTE: target user does NOT need to be signed in
 			SharedUserData? sharedUserDataSource = GenOnlineService.WebSocketManager.GetSharedDataForUser(source_user_id);
 			SharedUserData? sharedUserDataTarget = GenOnlineService.WebSocketManager.GetSharedDataForUser(target_user_id);
 
+			if (sharedUserDataSource == null)
+			{
+				return false;
+			}
+
 			await using var db = await _dbFactory.CreateDbContextAsync();
-			// NOTE: target user does NOT need to be signed in
+
+			// a friendship adds an entry to both lists, so the target must have room too
+			int targetFriendCount = sharedUserDataTarget != null
+				? sharedUserDataTarget.GetSocialContainer().Friends.Count
+				: await Database.Social.CountFriends(db, target_user_id);
+
+			if (targetFriendCount >= FriendsLimit)
+			{
+				return false;
+			}
 
 			// remove the request from requestor (online version)
-#pragma warning disable CS8602 // Dereference of a possibly null reference.
 			sharedUserDataSource.GetSocialContainer().PendingRequests.Remove(target_user_id);
-#pragma warning restore CS8602 // Dereference of a possibly null reference.
 
             // remove the request from requestor (db)
             await Database.Social.RemovePendingFriendRequest(db, source_user_id, target_user_id);
@@ -141,6 +172,8 @@ namespace GenOnlineService.Controllers
 				// send to all sessions
 				WebsocketHelper.SendToAllSessionsOfUser(target_user_id, bytesJSON);
 			}
+
+			return true;
         }
 
 		// Accept a request
@@ -150,13 +183,23 @@ namespace GenOnlineService.Controllers
 		{
 			// source user must be signed in (anywhere)
 			Int64 source_user_id = TokenHelper.GetUserID(this);
-			if (source_user_id == -1 || WebSocketManager.GetSharedDataForUser(source_user_id) == null)
+			SharedUserData? userData = WebSocketManager.GetSharedDataForUser(source_user_id);
+			if (source_user_id == -1 || userData == null)
 			{
 				Response.StatusCode = (int)HttpStatusCode.Forbidden;
 				return;
 			}
 
-			HelperFunction_AcceptFriendRequest(source_user_id, target_user_id);
+			if (RejectIfFriendsListFull(source_user_id, userData))
+			{
+				return;
+			}
+
+			if (!await HelperFunction_AcceptFriendRequest(source_user_id, target_user_id))
+			{
+				Response.StatusCode = (int)HttpStatusCode.Forbidden;
+				return;
+			}
 
 			SocialHelper.NotifyFriendslistDirty(source_user_id);
 			SocialHelper.NotifyFriendslistDirty(target_user_id);
@@ -169,17 +212,15 @@ namespace GenOnlineService.Controllers
 		{
 			// source user must be signed in
 			Int64 source_user_id = TokenHelper.GetUserID(this);
-			if (source_user_id == -1 || WebSocketManager.GetSharedDataForUser(source_user_id) == null)
+			SharedUserData? userData = WebSocketManager.GetSharedDataForUser(source_user_id);
+			if (source_user_id == -1 || userData == null)
 			{
 				Response.StatusCode = (int)HttpStatusCode.Forbidden;
 				return;
 			}
 
 			// remove the request from requestor (online version)
-#pragma warning disable CS8602 // Dereference of a possibly null reference.
-			SharedUserData? userData = WebSocketManager.GetSharedDataForUser(source_user_id);
 			userData.GetSocialContainer().PendingRequests.Remove(target_user_id);
-#pragma warning restore CS8602 // Dereference of a possibly null reference.
 
 			// remove the request from requestor (db)
 			// NOTE: Target and source are inverted here because the target is actually the person who sent the request, source is the person taking action on the friend request
@@ -197,21 +238,19 @@ namespace GenOnlineService.Controllers
 		{
 			// source user must be signed in
 			Int64 source_user_id = TokenHelper.GetUserID(this);
-			if (source_user_id == -1 || WebSocketManager.GetSharedDataForUser(source_user_id) == null)
+			SharedUserData? userData = WebSocketManager.GetSharedDataForUser(source_user_id);
+			if (source_user_id == -1 || userData == null)
 			{
 				Response.StatusCode = (int)HttpStatusCode.Forbidden;
 				return;
 			}
 
 			// must be friends
-#pragma warning disable CS8602 // Dereference of a possibly null reference.
-			SharedUserData? userData = WebSocketManager.GetSharedDataForUser(source_user_id);
 			if (!userData.GetSocialContainer().Friends.Contains(target_user_id))
 			{
 				Response.StatusCode = (int)HttpStatusCode.NotFound;
 				return;
 			}
-#pragma warning restore CS8602 // Dereference of a possibly null reference.
 
 			// remove the request from requestor (online version)
 			userData.GetSocialContainer().Friends.Remove(target_user_id);
@@ -239,36 +278,24 @@ namespace GenOnlineService.Controllers
 		{
 			// source user must be signed in
 			Int64 requester_user_id = TokenHelper.GetUserID(this);
-			if (requester_user_id == -1 || WebSocketManager.GetSharedDataForUser(requester_user_id) == null)
+			SharedUserData? userData = WebSocketManager.GetSharedDataForUser(requester_user_id);
+			if (requester_user_id == -1 || userData == null)
 			{
 				Response.StatusCode = (int)HttpStatusCode.Forbidden;
 				return;
 			}
 
-			// too many friends?
-			const int friendsLimit = 200;
-			SharedUserData? userData = WebSocketManager.GetSharedDataForUser(requester_user_id);
-			if (userData.GetSocialContainer().Friends.Count >= friendsLimit)
+			if (RejectIfFriendsListFull(requester_user_id, userData))
 			{
-				if (userData != null)
-				{
-					WebSocketMessage_Social_FriendsListFull friendsListFullEvent = new();
-					friendsListFullEvent.msg_id = (int)EWebSocketMessageID.SOCIAL_CANT_ADD_FRIEND_LIST_FULL;
-					byte[] bytesJSON = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(friendsListFullEvent));
-
-					// send to all sessions
-					WebsocketHelper.SendToAllSessionsOfUser(requester_user_id, bytesJSON);
-				}
-            }
+				return;
+			}
 
 			// Check not already friends
-#pragma warning disable CS8602 // Dereference of a possibly null reference.
 			if (userData.GetSocialContainer().Friends.Contains(target_user_id))
 			{
 				Response.StatusCode = (int)HttpStatusCode.Conflict;
 				return;
 			}
-#pragma warning restore CS8602 // Dereference of a possibly null reference.
 
 			await using var db = await _dbFactory.CreateDbContextAsync();
 
@@ -309,7 +336,11 @@ namespace GenOnlineService.Controllers
 			if (userData.GetSocialContainer().PendingRequests.Contains(target_user_id))
 			{
 				// accept their request
-                HelperFunction_AcceptFriendRequest(requester_user_id, target_user_id);
+                if (!await HelperFunction_AcceptFriendRequest(requester_user_id, target_user_id))
+                {
+                    Response.StatusCode = (int)HttpStatusCode.Forbidden;
+                    return;
+                }
             }
             else
 			{
@@ -341,18 +372,14 @@ namespace GenOnlineService.Controllers
 
 			// source user must be signed in
 			Int64 requester_user_id = TokenHelper.GetUserID(this);
-			if (requester_user_id == -1 || WebSocketManager.GetSharedDataForUser(requester_user_id) == null)
+			SharedUserData? sourceData = WebSocketManager.GetSharedDataForUser(requester_user_id);
+			if (requester_user_id == -1 || sourceData == null)
 			{
 				Response.StatusCode = (int)HttpStatusCode.Forbidden;
 				return result;
 			}
 
-			// get websockets & data
-			SharedUserData? sourceData = WebSocketManager.GetSharedDataForUser(requester_user_id);
-
-#pragma warning disable CS8602 // Dereference of a possibly null reference.
 			HashSet<Int64> setFriends = sourceData.GetSocialContainer().Friends;
-#pragma warning restore CS8602 // Dereference of a possibly null reference.
 			HashSet<Int64> setPendingRequests = sourceData.GetSocialContainer().PendingRequests;
 
 			List<Int64> lstCombined = new List<Int64>();
@@ -437,17 +464,14 @@ namespace GenOnlineService.Controllers
 
 			// source user must be signed in
 			Int64 requester_user_id = TokenHelper.GetUserID(this);
-			if (requester_user_id == -1 || WebSocketManager.GetSharedDataForUser(requester_user_id) == null)
+			SharedUserData? sourceData = WebSocketManager.GetSharedDataForUser(requester_user_id);
+			if (requester_user_id == -1 || sourceData == null)
 			{
 				Response.StatusCode = (int)HttpStatusCode.Forbidden;
 				return result;
 			}
 
-			SharedUserData? sourceData = WebSocketManager.GetSharedDataForUser(requester_user_id);
-
-#pragma warning disable CS8602 // Dereference of a possibly null reference.
 			HashSet<Int64> setBlocked = sourceData.GetSocialContainer().Blocked;
-#pragma warning restore CS8602 // Dereference of a possibly null reference.
 
 			await using var db = await _dbFactory.CreateDbContextAsync();
 			Dictionary<Int64, string> dictDisplayNames = await Database.Users.GetDisplayNameBulk(db, setBlocked.ToList());
@@ -500,16 +524,14 @@ namespace GenOnlineService.Controllers
 		{
 			// source user must be signed in
 			Int64 requester_user_id = TokenHelper.GetUserID(this);
-			if (requester_user_id == -1 || WebSocketManager.GetSharedDataForUser(requester_user_id) == null)
+			SharedUserData? sourceData = WebSocketManager.GetSharedDataForUser(requester_user_id);
+			if (requester_user_id == -1 || sourceData == null)
 			{
 				Response.StatusCode = (int)HttpStatusCode.Forbidden;
 				return;
 			}
 
 			// Check not already blocked
-			SharedUserData? sourceData = WebSocketManager.GetSharedDataForUser(requester_user_id);
-
-#pragma warning disable CS8602 // Dereference of a possibly null reference.
 			if (sourceData.GetSocialContainer().Blocked.Contains(target_user_id))
 			{
 				Response.StatusCode = (int)HttpStatusCode.Conflict;
@@ -526,8 +548,6 @@ namespace GenOnlineService.Controllers
 					return;
 				}
 			}
-
-#pragma warning restore CS8602 // Dereference of a possibly null reference.
 
 			// We must:
 			//// - Remove from source friends, DB (if present)
@@ -573,22 +593,19 @@ namespace GenOnlineService.Controllers
 
 			// source user must be signed in
 			Int64 requester_user_id = TokenHelper.GetUserID(this);
-			if (requester_user_id == -1 || WebSocketManager.GetSharedDataForUser(requester_user_id) == null)
+			SharedUserData? sourceData = WebSocketManager.GetSharedDataForUser(requester_user_id);
+			if (requester_user_id == -1 || sourceData == null)
 			{
 				Response.StatusCode = (int)HttpStatusCode.Forbidden;
 				return;
 			}
 
-			SharedUserData? sourceData = WebSocketManager.GetSharedDataForUser(requester_user_id);
-
 			// Check blocked
-#pragma warning disable CS8602 // Dereference of a possibly null reference.
 			if (!sourceData.GetSocialContainer().Blocked.Contains(target_user_id))
 			{
 				Response.StatusCode = (int)HttpStatusCode.Conflict;
 				return;
 			}
-#pragma warning restore CS8602 // Dereference of a possibly null reference.
 
 			// - Remove from block list (cache)
 			sourceData.GetSocialContainer().Blocked.Remove(target_user_id);

--- a/GenOnlineService/Database/Database.Social.cs
+++ b/GenOnlineService/Database/Database.Social.cs
@@ -100,6 +100,13 @@ namespace Database
 				  .Where(f => f.UserId1 == userId || f.UserId2 == userId)
 		);
 
+		private static readonly Func<AppDbContext, long, Task<int>> _countFriends =
+		EF.CompileAsyncQuery(
+			(AppDbContext db, long userId) =>
+				db.Friends
+				  .Count(f => f.UserId1 == userId || f.UserId2 == userId)
+		);
+
 		private static readonly Func<AppDbContext, long, IAsyncEnumerable<long>> _getBlocked =
 		EF.CompileAsyncQuery(
 			(AppDbContext db, long userId) =>
@@ -136,6 +143,23 @@ namespace Database
 			}
 
 			return result;
+		}
+
+
+		public static async Task<int> CountFriends(AppDbContext db, long userId)
+		{
+			try
+			{
+				return await _countFriends(db, userId);
+			}
+			catch (Exception ex)
+			{
+				Console.WriteLine($"[ERROR] CountFriends failed: {ex.Message}");
+				SentrySdk.CaptureException(ex);
+
+				// Treat an unreadable count as full so the friends limit is never bypassed.
+				return int.MaxValue;
+			}
 		}
 
 


### PR DESCRIPTION
- Enforce the 200 friend limit on every path that can grow a friends list: sending a request, accepting a request, and the mutual auto-accept.
- Enforce the limit for **both** participants, since accepting a request adds an entry to each user's list.
- Check an offline target's count against the database via a new `Database.Social.CountFriends` query.
- Await friend request acceptance so the database and cache are updated before notifications are sent and the request completes.
- Replace `CS8602` warning suppressions with real null checks on the caller's shared user data.

---

The friends limit was effectively advisory. `AddFriend` notified the client that the
list was full but then carried on and created the request anyway, and
`AcceptPendingRequest` had no limit check at all, so a user could sit at the cap and
keep accepting incoming requests.

The limit was also one-sided. Because a friendship writes to both users' lists,
accepting a request could push the *other* user past 200 even when the acting user
had room.

Separately, `HelperFunction_AcceptFriendRequest` was invoked without `await`. The
request could return, and the friends-list-dirty notifications could fire, before the
friendship row and cache updates had actually been written.

---

**`SocialController`**
- Added a `FriendsLimit` constant and a `RejectIfFriendsListFull` helper that notifies
  every session of the user and returns `403 Forbidden`.
- Applied that check to `AcceptPendingRequest` and `AddFriend`.
- `HelperFunction_AcceptFriendRequest` now verifies the target has room before creating
  the friendship and returns a `bool` so callers can respond with `403` and skip the
  friends-list-dirty notifications when nothing was created.
- Hoisted the `GetSharedDataForUser` lookups into the sign-in guards and reused the
  result, removing the duplicate lookups and the pragma suppressions.

**`Database.Social`**
- Added `CountFriends`, a compiled query for a user's friendship count.
- On a query failure it returns `int.MaxValue`, so an unreadable count blocks the
  friendship rather than silently bypassing the limit.

---

- `POST Friends/Requests/{id}` returns `403` when the accepting user is at the limit,
  and also emits `SOCIAL_CANT_ADD_FRIEND_LIST_FULL` to their sessions.
- `POST Friends/Requests/{id}` and `PUT Friends/Requests/{id}` return `403` without
  the websocket message when the *other* user is at the limit.
- `PUT Friends/Requests/{id}` no longer creates a pending request once the requester is
  at the limit; previously it warned and continued.