### PR TITLE
feat(match-history): expose executable and INI CRCs

### DIFF
--- a/GenOnlineService/Controllers/MatchUpdate/MatchUpdateController.cs
+++ b/GenOnlineService/Controllers/MatchUpdate/MatchUpdateController.cs
@@ -70,7 +70,9 @@ namespace GenOnlineService.Controllers
 		bool is_limit_superweapons,
 		bool is_tracking_stats,
 		bool allow_observers,
-		UInt16 max_camera_height
+		UInt16 max_camera_height,
+		UInt32 exe_crc,
+		UInt32 ini_crc
 		)
 		{
 			this.match_id = match_id;
@@ -89,6 +91,8 @@ namespace GenOnlineService.Controllers
 			this.is_tracking_stats = is_tracking_stats;
 			this.allow_observers = allow_observers;
 			this.max_camera_height = max_camera_height;
+			this.exe_crc = exe_crc;
+			this.ini_crc = ini_crc;
 		}
 
 		public Int64 match_id { get; set; } = -1;
@@ -108,6 +112,8 @@ namespace GenOnlineService.Controllers
 		public bool is_tracking_stats { get; set; } = false;
 		public bool allow_observers { get; set; } = false;
 		public UInt16 max_camera_height { get; set; } = 0;
+		public UInt32 exe_crc { get; set; } = 0;
+		public UInt32 ini_crc { get; set; } = 0;
 
 		public List<MatchdataMemberModel?> members { get; private set; } = new();
 	}

--- a/GenOnlineService/Database/Database.MatchHistory.cs
+++ b/GenOnlineService/Database/Database.MatchHistory.cs
@@ -47,6 +47,8 @@ public class MatchHistoryEntry
 	public bool TrackStats { get; set; }
 	public bool AllowObservers { get; set; }
 	public ushort MaxCamHeight { get; set; }
+	public uint ExeCRC { get; set; }
+	public uint IniCRC { get; set; }
 	public string? MapPath { get; set; }
 
 	// JSON slots
@@ -125,6 +127,14 @@ public class MatchHistoryConfiguration : IEntityTypeConfiguration<MatchHistoryEn
 		entity.Property(e => e.MaxCamHeight)
 			.HasColumnName("max_cam_height")
 			.HasColumnType("smallint unsigned");
+
+		entity.Property(e => e.ExeCRC)
+			.HasColumnName("exe_crc")
+			.HasColumnType("int unsigned");
+
+		entity.Property(e => e.IniCRC)
+			.HasColumnName("ini_crc")
+			.HasColumnType("int unsigned");
 
 		entity.Property(e => e.MapPath)
 			.HasColumnName("map_path")
@@ -476,6 +486,8 @@ namespace Database
 					TrackStats = lobby.IsTrackingStats,
 					AllowObservers = lobby.AllowObservers,
 					MaxCamHeight = lobby.MaximumCameraHeight,
+					ExeCRC = lobby.ExeCRC,
+					IniCRC = lobby.IniCRC,
 
 					MemberSlot0 = jsonSlots[0],
 					MemberSlot1 = jsonSlots[1],
@@ -750,6 +762,8 @@ namespace Database
 						m.TrackStats,
 						m.AllowObservers,
 						m.MaxCamHeight,
+						m.ExeCRC,
+						m.IniCRC,
 						m.MemberSlot0,
 						m.MemberSlot1,
 						m.MemberSlot2,
@@ -779,7 +793,9 @@ namespace Database
 						row.LimitSuperweapons,
 						row.TrackStats,
 						row.AllowObservers,
-						row.MaxCamHeight
+						row.MaxCamHeight,
+						row.ExeCRC,
+						row.IniCRC
 					);
 
 					AddMemberIfNotNull(entry, row.MemberSlot0);
@@ -831,7 +847,9 @@ namespace Database
 						row.LimitSuperweapons,
 						row.TrackStats,
 						row.AllowObservers,
-						row.MaxCamHeight
+						row.MaxCamHeight,
+						row.ExeCRC,
+						row.IniCRC
 					);
 
 					AddMemberIfNotNull(entry, row.MemberSlot0);
@@ -926,7 +944,9 @@ namespace Database
 				row.LimitSuperweapons,
 				row.TrackStats,
 				row.AllowObservers,
-				row.MaxCamHeight
+				row.MaxCamHeight,
+				row.ExeCRC,
+				row.IniCRC
 			);
 
 			AddMemberIfNotNull(entry, row.MemberSlot0);

--- a/GenOnlineService/Database_Structure/structure.sql
+++ b/GenOnlineService/Database_Structure/structure.sql
@@ -110,6 +110,8 @@ CREATE TABLE IF NOT EXISTS `match_history` (
   `track_stats` tinyint(1) NOT NULL,
   `allow_observers` tinyint(1) NOT NULL,
   `max_cam_height` smallint(6) unsigned NOT NULL,
+  `exe_crc` int(10) unsigned NOT NULL DEFAULT 0,
+  `ini_crc` int(10) unsigned NOT NULL DEFAULT 0,
   `map_path` varchar(128) DEFAULT NULL,
   `member_slot_0` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL CHECK (json_valid(`member_slot_0`)),
   `member_slot_1` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL CHECK (json_valid(`member_slot_1`)),


### PR DESCRIPTION
Add executable and INI CRC values to persisted match history and API responses.

---

- Store lobby `exe_crc` and `ini_crc` values when creating match-history entries
- Map both values as unsigned database columns
- Include both CRCs in all match-history response paths
- Update the baseline database schema with default values for existing records

---

Existing databases require the following schema update before deploying the service:

```sql
ALTER TABLE `match_history`
  ADD COLUMN `exe_crc` INT UNSIGNED NOT NULL DEFAULT 0,
  ADD COLUMN `ini_crc` INT UNSIGNED NOT NULL DEFAULT 0;