### PR TITLE
feat: store LobbyType per match and thread through API Responses

### DIFF
--- a/GenOnlineService/Controllers/MatchUpdate/MatchUpdateController.cs
+++ b/GenOnlineService/Controllers/MatchUpdate/MatchUpdateController.cs
@@ -64,6 +64,7 @@ namespace GenOnlineService.Controllers
 		string map_name,
 		string map_path,
 		string match_roster_type,
+		ELobbyType? lobby_type,
 		bool is_official_map,
 		bool vanilla_teams_only,
 		UInt32 starting_cash,
@@ -84,6 +85,7 @@ namespace GenOnlineService.Controllers
 			this.map_name = map_name;
 			this.map_path = map_path;
 			this.match_roster_type = match_roster_type;
+			this.lobby_type = lobby_type;
 			this.is_official_map = is_official_map;
 			this.vanilla_teams_only = vanilla_teams_only;
 			this.starting_cash = starting_cash;
@@ -105,6 +107,7 @@ namespace GenOnlineService.Controllers
 		public string map_path { get; set; } = String.Empty;
 
 		public string match_roster_type { get; set; } = String.Empty;
+		public ELobbyType? lobby_type { get; set; } = null;
 		public bool is_official_map { get; set; } = false;
 		public bool vanilla_teams_only { get; set; } = false;
 		public UInt32 starting_cash { get; set; } = 0;

--- a/GenOnlineService/Database/Database.MatchHistory.cs
+++ b/GenOnlineService/Database/Database.MatchHistory.cs
@@ -41,6 +41,7 @@ public class MatchHistoryEntry
 	public string MapName { get; set; } = string.Empty;
 	public bool MapOfficial { get; set; }
 	public string MatchRosterType { get; set; } = string.Empty;
+	public ELobbyType? LobbyType { get; set; } = null;
 	public bool VanillaTeams { get; set; }
 	public uint StartingCash { get; set; }
 	public bool LimitSuperweapons { get; set; }
@@ -107,6 +108,11 @@ public class MatchHistoryConfiguration : IEntityTypeConfiguration<MatchHistoryEn
 			.HasColumnName("match_roster_type")
 			.HasMaxLength(32)
 			.HasDefaultValue("");
+
+		entity.Property(e => e.LobbyType)
+			.HasColumnName("lobby_type")
+			.HasConversion<byte?>()
+			.HasColumnType("tinyint unsigned");
 
 		entity.Property(e => e.VanillaTeams)
 			.HasColumnName("vanilla_teams");
@@ -480,6 +486,7 @@ namespace Database
 					MapPath = lobby.MapPath,
 					MapOfficial = lobby.IsMapOfficial,
 					MatchRosterType = rosterType,
+					LobbyType = lobby.LobbyType,
 					VanillaTeams = lobby.IsVanillaTeamsOnly,
 					StartingCash = lobby.StartingCash,
 					LimitSuperweapons = lobby.IsLimitSuperweapons,
@@ -755,6 +762,7 @@ namespace Database
 						m.MapName,
 						m.MapPath,
 						m.MatchRosterType,
+						m.LobbyType,
 						m.MapOfficial,
 						m.VanillaTeams,
 						m.StartingCash,
@@ -787,6 +795,7 @@ namespace Database
 						row.MapName,
 						row.MapPath ?? string.Empty,
 						row.MatchRosterType,
+						row.LobbyType,
 						row.MapOfficial,
 						row.VanillaTeams,
 						row.StartingCash,
@@ -841,6 +850,7 @@ namespace Database
 						row.MapName,
 						row.MapPath ?? string.Empty,
 						row.MatchRosterType,
+						row.LobbyType,
 						row.MapOfficial,
 						row.VanillaTeams,
 						row.StartingCash,
@@ -938,6 +948,7 @@ namespace Database
 				row.MapName,
 				row.MapPath ?? string.Empty,
 				row.MatchRosterType,
+				row.LobbyType,
 				row.MapOfficial,
 				row.VanillaTeams,
 				row.StartingCash,

--- a/GenOnlineService/Database_Structure/structure.sql
+++ b/GenOnlineService/Database_Structure/structure.sql
@@ -104,6 +104,7 @@ CREATE TABLE IF NOT EXISTS `match_history` (
   `map_name` varchar(128) NOT NULL,
   `map_official` tinyint(1) NOT NULL,
   `match_roster_type` varchar(32) NOT NULL DEFAULT '',
+  `lobby_type` tinyint(3) unsigned DEFAULT NULL,
   `vanilla_teams` tinyint(1) NOT NULL,
   `starting_cash` int(10) unsigned NOT NULL,
   `limit_superweapons` tinyint(1) NOT NULL,


### PR DESCRIPTION
```
ALTER TABLE `match_history`
  ADD COLUMN `lobby_type` tinyint(3) unsigned NULL DEFAULT NULL AFTER `match_roster_type`;
```

Run this query on db before going live with this