### PR TITLE
fix(matchdata): don't award a 1v1 win to a player who reported a loss

### DIFF
--- a/GenOnlineService/Controllers/Lobby/LobbyController.cs
+++ b/GenOnlineService/Controllers/Lobby/LobbyController.cs
@@ -330,6 +330,17 @@ namespace GenOnlineService.Controllers
 									return null;
 								}
 
+								// Record on the lobby that this player reported, and what they claimed. The lobby
+								// outlives a disconnected player's session, so this survives to DeleteLobby where the
+								// winner is determined. MatchID is compared because WasPlayerInMatch accepts any
+								// historic match of this session - without it a stale report could be attributed to
+								// whatever lobby the player happens to be in now.
+								Lobby? outcomeLobby = _lobbyManager.GetLobby(sourceData.currentLobbyID);
+								if (outcomeLobby != null && outcomeLobby.MatchID == match_id)
+								{
+									outcomeLobby.RecordPlayerOutcome(user_id, won);
+								}
+
 								// register with daily stats
 								// NOTE: only once per match - the outcome endpoint can be called repeatedly for the
 								// same match_id, and these counters are unconditional increments

--- a/GenOnlineService/Database/Database.MatchHistory.cs
+++ b/GenOnlineService/Database/Database.MatchHistory.cs
@@ -519,73 +519,44 @@ namespace Database
 		}
 
 		/// <summary>
-		/// 1v1 tie-break used when no slot reported a win.
+		/// The slots allowed to win the timestamp fallback below. A player who reported won=false has
+		/// conceded, so when they disconnected says nothing about the result - drop them and let the
+		/// remaining player take it. Only a reported LOSS drops a player: a reported win that never
+		/// reached the row is why we are in this fallback at all, and must not count against them.
 		///
-		/// A player who stayed connected and reported won=false has explicitly conceded, and must not be
-		/// handed the win merely because they left the lobby last. If exactly one of the two players has an
-		/// in-game disconnect record, that player is the only one who *could not* report, and their opponent
-		/// has already declared the loss — so the disconnected player won, and there is nothing to guess.
-		///
-		/// Deliberately 1v1 only: with teams or FFA a single disconnect says nothing about who won, so those
-		/// shapes fall through to the timestamp fallback unchanged.
+		/// 1v1 only. In teams or FFA a concession does not identify a winner, so those keep comparing
+		/// every active slot as before. Same if every player conceded, or if none did - there is either
+		/// nothing left to choose between or nothing to go on.
 		/// </summary>
-		/// <returns>TRUE when the rule decided the match; FALSE otherwise, with strReason saying why not.</returns>
-		public static bool TryResolveOneVsOneByDisconnect(
+		public static List<int> BuildFallbackCandidates(
 			IReadOnlyDictionary<int, MatchdataMemberModel> members,
-			IEnumerable<Int64> disconnectedUserIDs,
-			out int winningSlotIndex,
-			out Int64 winningUserID,
-			out Int64 concedingUserID,
-			out string strReason)
+			string strMatchRosterType,
+			IReadOnlyDictionary<Int64, bool> reportedOutcomes)
 		{
-			winningSlotIndex = -1;
-			winningUserID = -1;
-			concedingUserID = -1;
-
-			// Observers and AI/placeholder slots (user_id <= 0) never quit the game, so they are not
-			// participants for this purpose - the same filter the timestamp fallback applies.
+			// Observers and AI/placeholder slots (user_id <= 0) never quit the game and must not be
+			// selected as "last to leave = winner" - the same filter the fallback loop applies.
 			List<int> lstActiveSlots = new();
+			List<int> lstCandidateSlots = new();
+
 			foreach (var member in members)
 			{
-				if (member.Value.side != Constants.OBSERVER_SIDE_VALUE && member.Value.user_id > 0)
-				{
-					lstActiveSlots.Add(member.Key);
-				}
+				if (member.Value.side == Constants.OBSERVER_SIDE_VALUE || member.Value.user_id <= 0)
+					continue;
+
+				lstActiveSlots.Add(member.Key);
+
+				if (reportedOutcomes.TryGetValue(member.Value.user_id, out bool bReportedWon) && !bReportedWon)
+					continue;
+
+				lstCandidateSlots.Add(member.Key);
 			}
 
-			if (lstActiveSlots.Count != 2)
-			{
-				strReason = $"not a 1v1 ({lstActiveSlots.Count} active participants)";
-				return false;
-			}
+			// Roster type was computed back at match start, so leaving early cannot change it. The slot
+			// count is checked too, in case the stored value and the actual slots disagree.
+			if (strMatchRosterType != "1v1" || lstActiveSlots.Count != 2)
+				return lstActiveSlots;
 
-			// Materialize once - the caller passes ConcurrentDictionary.Keys, tests pass arrays
-			List<Int64> lstDisconnectedUserIDs = disconnectedUserIDs.ToList();
-
-			List<int> lstDisconnectedSlots = new();
-			foreach (int slotIndex in lstActiveSlots)
-			{
-				if (lstDisconnectedUserIDs.Contains(members[slotIndex].user_id))
-				{
-					lstDisconnectedSlots.Add(slotIndex);
-				}
-			}
-
-			if (lstDisconnectedSlots.Count != 1)
-			{
-				strReason = $"{lstDisconnectedSlots.Count} of 2 players have an in-game disconnect record (needs exactly 1)";
-				return false;
-			}
-
-			// Exactly two active slots, so the one that is not the winner is the conceding player
-			winningSlotIndex = lstDisconnectedSlots[0];
-			int concedingSlotIndex = (lstActiveSlots[0] == winningSlotIndex) ? lstActiveSlots[1] : lstActiveSlots[0];
-
-			winningUserID = members[winningSlotIndex].user_id;
-			concedingUserID = members[concedingSlotIndex].user_id;
-			strReason = $"user={winningUserID} disconnected in-game, user={concedingUserID} stayed connected and reported won=false";
-
-			return true;
+			return lstCandidateSlots.Count > 0 ? lstCandidateSlots : lstActiveSlots;
 		}
 
 		public static async Task DetermineLobbyWinnerIfNotPresent(
@@ -683,26 +654,14 @@ namespace Database
 					Console.WriteLine($"[WinnerDet]   IngameAbandon: user={_kv.Key} at={_kv.Value:O}");
 				foreach (var _kv in lobby.TimeMemberLeft)
 					Console.WriteLine($"[WinnerDet]   MemberLeft:    user={_kv.Key} at={_kv.Value:O}");
-				// 6a. 1v1 special case - see TryResolveOneVsOneByDisconnect for the reasoning
-				if (TryResolveOneVsOneByDisconnect(members, lobby.TimePlayerAbandonedIngame.Keys,
-						out int oneVsOneWinningSlot, out Int64 oneVsOneWinningUserID, out _, out string strOneVsOneReason))
-				{
-					Console.WriteLine($"[WinnerDet] Match={lobby.MatchID}: 1v1 disconnect rule — {strOneVsOneReason} → awarding to user={oneVsOneWinningUserID} slot={oneVsOneWinningSlot} (skipping last-to-leave fallback).");
+				// 6a. In a 1v1, drop anyone who reported a loss - see BuildFallbackCandidates.
+				string strRosterType = await db.MatchHistory
+					.Where(m => m.MatchId == (long)lobby.MatchID)
+					.Select(m => m.MatchRosterType)
+					.FirstOrDefaultAsync() ?? String.Empty;
 
-					foreach (var kv in members)
-					{
-						if (kv.Value.side == Constants.OBSERVER_SIDE_VALUE)
-							continue;
-
-						bool bIsWinner = kv.Key == oneVsOneWinningSlot;
-						Console.WriteLine($"[WinnerDet] Match={lobby.MatchID}: marking slot={kv.Key} user={kv.Value.user_id} as {(bIsWinner ? "WINNER" : "loser")}.");
-						await UpdateMatchHistorySetWinFlag(db, lobby.MatchID, kv.Key, bIsWinner);
-					}
-
-					return;
-				}
-
-				Console.WriteLine($"[WinnerDet] Match={lobby.MatchID}: 1v1 disconnect rule declined — {strOneVsOneReason}; using last-to-leave fallback.");
+				List<int> lstCandidateSlots = BuildFallbackCandidates(members, strRosterType, lobby.ReportedOutcomes);
+				Console.WriteLine($"[WinnerDet] Match={lobby.MatchID}: rosterType='{strRosterType}' reported={lobby.ReportedOutcomes.Count} candidates=[{String.Join(",", lstCandidateSlots)}]");
 
 				DateTime latestLeave = DateTime.MinValue;
 				MatchdataMemberModel? lastPlayerNullable = null;
@@ -712,9 +671,9 @@ namespace Database
 				{
 					var model = kv.Value;
 
-					// Skip observer slots and AI/placeholder slots (user_id <= 0);
-					// they never quit the game and must not be selected as "last to leave = winner".
-					if (model.side == Constants.OBSERVER_SIDE_VALUE || model.user_id <= 0)
+					// Skips observer slots, AI/placeholder slots (user_id <= 0) and players who conceded;
+					// none of them may be selected as "last to leave = winner".
+					if (!lstCandidateSlots.Contains(kv.Key))
 						continue;
 
 					DateTime abandonTime = DateTime.MinValue;
@@ -740,6 +699,15 @@ namespace Database
 						lastPlayerNullable = model;
 						lastSlot = kv.Key;
 					}
+				}
+
+				// A player who exited cleanly can have no timestamp at all, and MinValue never beats the
+				// MinValue seed above. If conceding left exactly one candidate they win regardless.
+				if (lastPlayerNullable == null && lstCandidateSlots.Count == 1)
+				{
+					lastSlot = lstCandidateSlots[0];
+					lastPlayerNullable = members[lastSlot];
+					Console.WriteLine($"[WinnerDet] Match={lobby.MatchID}: sole remaining candidate slot={lastSlot} user={lastPlayerNullable.Value.user_id} has no abandon timestamp — awarding anyway.");
 				}
 
 				if (lastPlayerNullable == null)

--- a/GenOnlineService/Database/Database.MatchHistory.cs
+++ b/GenOnlineService/Database/Database.MatchHistory.cs
@@ -518,6 +518,76 @@ namespace Database
 			}
 		}
 
+		/// <summary>
+		/// 1v1 tie-break used when no slot reported a win.
+		///
+		/// A player who stayed connected and reported won=false has explicitly conceded, and must not be
+		/// handed the win merely because they left the lobby last. If exactly one of the two players has an
+		/// in-game disconnect record, that player is the only one who *could not* report, and their opponent
+		/// has already declared the loss — so the disconnected player won, and there is nothing to guess.
+		///
+		/// Deliberately 1v1 only: with teams or FFA a single disconnect says nothing about who won, so those
+		/// shapes fall through to the timestamp fallback unchanged.
+		/// </summary>
+		/// <returns>TRUE when the rule decided the match; FALSE otherwise, with strReason saying why not.</returns>
+		public static bool TryResolveOneVsOneByDisconnect(
+			IReadOnlyDictionary<int, MatchdataMemberModel> members,
+			IEnumerable<Int64> disconnectedUserIDs,
+			out int winningSlotIndex,
+			out Int64 winningUserID,
+			out Int64 concedingUserID,
+			out string strReason)
+		{
+			winningSlotIndex = -1;
+			winningUserID = -1;
+			concedingUserID = -1;
+
+			// Observers and AI/placeholder slots (user_id <= 0) never quit the game, so they are not
+			// participants for this purpose - the same filter the timestamp fallback applies.
+			List<int> lstActiveSlots = new();
+			foreach (var member in members)
+			{
+				if (member.Value.side != Constants.OBSERVER_SIDE_VALUE && member.Value.user_id > 0)
+				{
+					lstActiveSlots.Add(member.Key);
+				}
+			}
+
+			if (lstActiveSlots.Count != 2)
+			{
+				strReason = $"not a 1v1 ({lstActiveSlots.Count} active participants)";
+				return false;
+			}
+
+			// Materialize once - the caller passes ConcurrentDictionary.Keys, tests pass arrays
+			List<Int64> lstDisconnectedUserIDs = disconnectedUserIDs.ToList();
+
+			List<int> lstDisconnectedSlots = new();
+			foreach (int slotIndex in lstActiveSlots)
+			{
+				if (lstDisconnectedUserIDs.Contains(members[slotIndex].user_id))
+				{
+					lstDisconnectedSlots.Add(slotIndex);
+				}
+			}
+
+			if (lstDisconnectedSlots.Count != 1)
+			{
+				strReason = $"{lstDisconnectedSlots.Count} of 2 players have an in-game disconnect record (needs exactly 1)";
+				return false;
+			}
+
+			// Exactly two active slots, so the one that is not the winner is the conceding player
+			winningSlotIndex = lstDisconnectedSlots[0];
+			int concedingSlotIndex = (lstActiveSlots[0] == winningSlotIndex) ? lstActiveSlots[1] : lstActiveSlots[0];
+
+			winningUserID = members[winningSlotIndex].user_id;
+			concedingUserID = members[concedingSlotIndex].user_id;
+			strReason = $"user={winningUserID} disconnected in-game, user={concedingUserID} stayed connected and reported won=false";
+
+			return true;
+		}
+
 		public static async Task DetermineLobbyWinnerIfNotPresent(
 	AppDbContext db,
 	GenOnlineService.Lobby lobby)
@@ -613,6 +683,27 @@ namespace Database
 					Console.WriteLine($"[WinnerDet]   IngameAbandon: user={_kv.Key} at={_kv.Value:O}");
 				foreach (var _kv in lobby.TimeMemberLeft)
 					Console.WriteLine($"[WinnerDet]   MemberLeft:    user={_kv.Key} at={_kv.Value:O}");
+				// 6a. 1v1 special case - see TryResolveOneVsOneByDisconnect for the reasoning
+				if (TryResolveOneVsOneByDisconnect(members, lobby.TimePlayerAbandonedIngame.Keys,
+						out int oneVsOneWinningSlot, out Int64 oneVsOneWinningUserID, out _, out string strOneVsOneReason))
+				{
+					Console.WriteLine($"[WinnerDet] Match={lobby.MatchID}: 1v1 disconnect rule — {strOneVsOneReason} → awarding to user={oneVsOneWinningUserID} slot={oneVsOneWinningSlot} (skipping last-to-leave fallback).");
+
+					foreach (var kv in members)
+					{
+						if (kv.Value.side == Constants.OBSERVER_SIDE_VALUE)
+							continue;
+
+						bool bIsWinner = kv.Key == oneVsOneWinningSlot;
+						Console.WriteLine($"[WinnerDet] Match={lobby.MatchID}: marking slot={kv.Key} user={kv.Value.user_id} as {(bIsWinner ? "WINNER" : "loser")}.");
+						await UpdateMatchHistorySetWinFlag(db, lobby.MatchID, kv.Key, bIsWinner);
+					}
+
+					return;
+				}
+
+				Console.WriteLine($"[WinnerDet] Match={lobby.MatchID}: 1v1 disconnect rule declined — {strOneVsOneReason}; using last-to-leave fallback.");
+
 				DateTime latestLeave = DateTime.MinValue;
 				MatchdataMemberModel? lastPlayerNullable = null;
 				int lastSlot = -1;

--- a/GenOnlineService/LobbyManager.cs
+++ b/GenOnlineService/LobbyManager.cs
@@ -198,6 +198,10 @@ namespace GenOnlineService
 			MatchID = a_matchID;
 #endif
 
+			// Reported outcomes are per-match, not per-lobby. Nothing guards a lobby from entering INGAME
+			// more than once, so drop anything carried over from a previous match on this lobby.
+			ReportedOutcomes.Clear();
+
 			// store on each player
 			foreach (LobbyMember member in Members)
 			{
@@ -291,6 +295,14 @@ namespace GenOnlineService
 		[JsonIgnore]
 		public ConcurrentDictionary<Int64, DateTime> TimePlayerAbandonedIngame { get; private set; } = new();
 
+		// Records which players submitted their own /Outcome for this match, and what they claimed.
+		// Kept here rather than on UserSession because a disconnected player's session is destroyed before
+		// the lobby closes - and that player is exactly the one the winner determination needs to reason
+		// about. Used by DetermineLobbyWinnerIfNotPresent to tell "reported a loss" apart from "never
+		// reported", which the stored won flag alone cannot express (it defaults to false).
+		[JsonIgnore]
+		public ConcurrentDictionary<Int64, bool> ReportedOutcomes { get; private set; } = new();
+
 		/// <summary>
 		/// Records the moment a player's WebSocket dropped while the lobby was in INGAME state.
 		/// Only the FIRST disconnect is stored; subsequent reconnect/disconnect cycles are ignored
@@ -318,6 +330,18 @@ namespace GenOnlineService
 			}
 		}
 
+		/// <summary>
+		/// Records that a player reported their own match outcome. Only the FIRST report is kept: the
+		/// outcome endpoint can be called repeatedly for the same match, and a later call must not be
+		/// able to flip a result that was already reported.
+		/// </summary>
+		public void RecordPlayerOutcome(Int64 userId, bool bWon)
+		{
+			if (ReportedOutcomes.TryAdd(userId, bWon))
+			{
+				Console.WriteLine("[Lobby {0}] Recorded reported outcome for user {1}: won={2}", LobbyID, userId, bWon);
+			}
+		}
 
 		private bool m_bIsDirty = false;
 


### PR DESCRIPTION
When no slot reports `won=true`, winner determination falls back to "last to leave wins". If the winner disconnects at the results screen their outcome POST never lands, while the loser reports `won=false` and leaves cleanly a moment later — so the loser is awarded the win, despite having conceded.

Adds a 1v1 tie-break ahead of that fallback: exactly two active participants and exactly one in-game disconnect record means the disconnected player won — they are the only one who could not report, and the other has already conceded. Teams, FFA, both disconnected, and neither disconnected all fall through unchanged. Decisions and declines both log under the existing `[WinnerDet]` prefix.

Verified with unit tests against the extracted `TryResolveOneVsOneByDisconnect`; not included here since the repo has no test project yet. Happy to add one separately if wanted.