### PR TITLE
Apply Configured MySQL Connection Pool Settings

### DIFF
--- a/GenOnlineService/Program.cs
+++ b/GenOnlineService/Program.cs
@@ -400,10 +400,12 @@ namespace GenOnlineService
 			string? password = dbSettings.GetValue<string>("db_password");
 			UInt16? port = dbSettings.GetValue<UInt16>("db_port");
 
-			int? db_min_poolsize = dbSettings.GetValue<int>("db_min_poolsize");
-			int? db_max_poolsize = dbSettings.GetValue<int>("db_max_poolsize");
-			bool? db_use_pooling = dbSettings.GetValue<bool>("db_use_pooling");
-			bool? db_conn_reset = dbSettings.GetValue<bool>("db_conn_reset");
+			// Fall back to MySql.Data's own defaults when a key is absent, rather than silently
+			// disabling pooling / zeroing the pool size for deployments predating these settings.
+			int db_min_poolsize = dbSettings.GetValue<int?>("db_min_poolsize") ?? 0;
+			int db_max_poolsize = dbSettings.GetValue<int?>("db_max_poolsize") ?? 100;
+			bool db_use_pooling = dbSettings.GetValue<bool?>("db_use_pooling") ?? true;
+			bool db_conn_reset = dbSettings.GetValue<bool?>("db_conn_reset") ?? true;
 			int? db_connect_timeout = dbSettings.GetValue<int>("db_connect_timeout");
 			int? db_command_timeout = dbSettings.GetValue<int>("db_command_timeout");
 
@@ -451,7 +453,11 @@ namespace GenOnlineService
 					Password = password,
 					ConnectionTimeout = (uint)db_connect_timeout,
 					DefaultCommandTimeout = (uint)db_command_timeout,
-					SslMode = MySql.Data.MySqlClient.MySqlSslMode.Preferred
+					SslMode = MySql.Data.MySqlClient.MySqlSslMode.Preferred,
+					Pooling = db_use_pooling,
+					MinimumPoolSize = (uint)db_min_poolsize,
+					MaximumPoolSize = (uint)db_max_poolsize,
+					ConnectionReset = db_conn_reset
 				};
 
 				// TODO_EFCORE: Consider use of ExecuteDeleteAsync and options.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);

--- a/GenOnlineService/appsettings.json
+++ b/GenOnlineService/appsettings.json
@@ -57,7 +57,11 @@
     "db_password": "dbpassword",
     "db_port": 3306,
     "db_connect_timeout": 10,
-    "db_command_timeout": 10
+    "db_command_timeout": 10,
+    "db_min_poolsize": 10,
+    "db_max_poolsize": 500,
+    "db_use_pooling": true,
+    "db_conn_reset": true
   },
   "MatchData": {
     "upload_match_data": false,


### PR DESCRIPTION
oh what a Cerv in the PR's?  someone stop this man. full disclosure this PR text are my ramblings turned into a coherent PR by john Co Pilot.

## Summary

The database pool settings were read from configuration but never applied to the MySQL connection string.

As a result, production silently used MySql.Data defaults instead of the configured pool size. This could cap the application at approximately 100 connections despite `db_max_poolsize` being configured as `500`.

## Changes

- Apply `db_min_poolsize` to `MinimumPoolSize`.
- Apply `db_max_poolsize` to `MaximumPoolSize`.
- Apply `db_use_pooling` to `Pooling`.
- Apply `db_conn_reset` to `ConnectionReset`.
- Add the pool settings to the sample `appsettings.json`. (this seems to be allready set in prod just not in the template i guess) 
- Preserve MySql.Data defaults when older deployments omit these settings.

## Configuration

Production should include:

```json
{
  "Database": {
    "db_min_poolsize": 10,
    "db_max_poolsize": 500,
    "db_use_pooling": true,
    "db_conn_reset": true
  }
}
```

dotnet build ran without issues and warnings. 

This PR is technically related to a general issue in DB pooling and possible exhaustion but focuses on adressing only the con pool config issue.

C# aint my strong sword but this server magic is feel free to critisize and call me names if i fucked up.

