### PR TITLE
Isolate Database Contexts During External Leaderboard Requests

### DIFF
--- a/GenOnlineService/ExternalLeaderboardsClient.cs
+++ b/GenOnlineService/ExternalLeaderboardsClient.cs
@@ -10,6 +10,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Polly;
 
@@ -122,7 +123,7 @@ namespace GenOnlineService
             };
         }
 
-        public static async Task PostMatchResultAsync(AppDbContext db, Lobby lobby)
+        public static async Task PostMatchResultAsync(IDbContextFactory<AppDbContext> dbFactory, Lobby lobby)
         {
             if (lobby.MatchID == 0)
                 return;
@@ -131,8 +132,14 @@ namespace GenOnlineService
             {
                 GetExternalLeaderboardsConfig(out string postUrl, out _, out string postToken, out _);
 
-                // Load the match payload
-                var matchEntry = await Database.MatchHistory.LoadMatchHistoryEntryAsync(db, (long)lobby.MatchID);
+                // Load the match payload. Context is closed before the HTTP call so the pooled connection
+                // isn't held open for the (potentially multi-minute, with retries) external request below.
+                Controllers.MatchHistory_Entry? matchEntry;
+                await using (var readDb = await dbFactory.CreateDbContextAsync())
+                {
+                    matchEntry = await Database.MatchHistory.LoadMatchHistoryEntryAsync(readDb, (long)lobby.MatchID);
+                }
+
                 if (matchEntry == null)
                 {
                     Console.WriteLine($"[WARNING] MatchHistory entry not found for match ID {lobby.MatchID}");
@@ -206,6 +213,9 @@ namespace GenOnlineService
                 // Only player IDs that were actually part of this match are valid recipients of an ELO update.
                 var expectedPlayerIds = new HashSet<long>(matchEntry.members.Where(m => m.HasValue).Select(m => m.Value.user_id));
 
+                // Fresh, short-lived context just for the persistence writes below.
+                await using var writeDb = await dbFactory.CreateDbContextAsync();
+
                 foreach (var (userId, updatedPlayer) in refreshResponse.data)
                 {
                     if (!expectedPlayerIds.Contains(userId))
@@ -228,7 +238,7 @@ namespace GenOnlineService
                     }
 
                     // Call SaveELOData to persist as fallback
-                    await Database.Users.SaveELOData(db, userId, new EloData(newRating, newMonthlyRating, newMatches));
+                    await Database.Users.SaveELOData(writeDb, userId, new EloData(newRating, newMonthlyRating, newMatches));
                 }
             }
             catch (Exception ex)

--- a/GenOnlineService/ExternalLeaderboardsClient.cs
+++ b/GenOnlineService/ExternalLeaderboardsClient.cs
@@ -132,8 +132,7 @@ namespace GenOnlineService
             {
                 GetExternalLeaderboardsConfig(out string postUrl, out _, out string postToken, out _);
 
-                // Load the match payload. Context is closed before the HTTP call so the pooled connection
-                // isn't held open for the (potentially multi-minute, with retries) external request below.
+                // Dispose the read context before the potentially multi-minute external request below.
                 Controllers.MatchHistory_Entry? matchEntry;
                 await using (var readDb = await dbFactory.CreateDbContextAsync())
                 {

--- a/GenOnlineService/LobbyManager.cs
+++ b/GenOnlineService/LobbyManager.cs
@@ -1583,7 +1583,8 @@ namespace GenOnlineService
 
 					// Post match result to external leaderboard API for every lobby type.
 					// Only QuickMatch responses are expected to carry a ratings body.
-					await ExternalLeaderboardsClient.PostMatchResultAsync(db, lobby);
+					// Uses its own short-lived DbContexts internally so this call's HTTP retries don't pin the pooled connection above.
+					await ExternalLeaderboardsClient.PostMatchResultAsync(factory, lobby);
 				}
 
 				return bRemoved;

--- a/GenOnlineService/LobbyManager.cs
+++ b/GenOnlineService/LobbyManager.cs
@@ -1406,15 +1406,10 @@ public async Task FinalizeACChecks()
 		private Int64 m_NextLobbyID = 0;
 
 		private readonly IServiceProvider _services;
-		private readonly AppDbContext _db;
 
 		public LobbyManager(IServiceProvider services)
 		{
 			_services = services;
-
-            var scope = _services.CreateScope();
-            var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<AppDbContext>>();
-            var _db = factory.CreateDbContext();
         }
 
         public async Task Cleanup()
@@ -1720,13 +1715,17 @@ public async Task FinalizeACChecks()
 		{
 			try
 			{
+				using var scope = _services.CreateScope();
+				var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<AppDbContext>>();
+				await using var db = await factory.CreateDbContextAsync();
+
 				if (lobby.State != ELobbyState.COMPLETE)
 				{
 					// make done
 					await lobby.UpdateState(ELobbyState.COMPLETE);
 
 					// attempt to commit it
-					await Database.MatchHistory.CommitLobbyToMatchHistory(_db, lobby);
+					await Database.MatchHistory.CommitLobbyToMatchHistory(db, lobby);
 				}
 
 				// delete
@@ -1740,11 +1739,11 @@ public async Task FinalizeACChecks()
 					lobby.OnLobbyNeedsDestroyed -= HandleLobbyNeedsDestroyed;
 
 					// make sure we have a winner
-					await Database.MatchHistory.DetermineLobbyWinnerIfNotPresent(_db, lobby);
+					await Database.MatchHistory.DetermineLobbyWinnerIfNotPresent(db, lobby);
 
 					// Post match result to external leaderboard API for every lobby type.
 					// Only QuickMatch responses are expected to carry a ratings body.
-					await ExternalLeaderboardsClient.PostMatchResultAsync(_db, lobby);
+					await ExternalLeaderboardsClient.PostMatchResultAsync(factory, lobby);
 				}
 
 				return bRemoved;

--- a/GenOnlineService/LobbyManager.cs
+++ b/GenOnlineService/LobbyManager.cs
@@ -1583,7 +1583,6 @@ namespace GenOnlineService
 
 					// Post match result to external leaderboard API for every lobby type.
 					// Only QuickMatch responses are expected to carry a ratings body.
-					// Uses its own short-lived DbContexts internally so this call's HTTP retries don't pin the pooled connection above.
 					await ExternalLeaderboardsClient.PostMatchResultAsync(factory, lobby);
 				}
 


### PR DESCRIPTION
another cerv? :o  again ramblings turned into coherent text by water guzzler john co pilot.

## Summary

This PR separates the database contexts used by the external leaderboard flow from the context owned by `LobbyManager`.

The change is technically related to the recent database connection-exhaustion, but it is primarily a sanity and resource-lifetime cleanup. It should not be considered the primary fix for the incident. It should also be double checked if its actually smth yall want or nah its a sanity thing really not critical just making sure things get handled cleaner

## Changes

- `PostMatchResultAsync` now receives an `IDbContextFactory<AppDbContext>` instead of a caller-owned `AppDbContext`.
- A short-lived context is used to load the match payload.
- That read context is disposed before the external HTTP request and retry sequence begins.
- A separate short-lived context is used for persisting returned ELO data.
- `LobbyManager.DeleteLobby` now passes the context factory instead of its active context.

## Why

The external leaderboard request can involve retries and significant delays. Keeping the caller's `DbContext` in scope throughout that operation is unnecessary and makes resource ownership less clear.

Using independently scoped contexts ensures that:

- The HTTP retry path does not retain the caller's context.
- Database reads and writes have clear, limited lifetimes.
- Future changes to the external request flow are less likely to accidentally hold database resources across network operations.

## Scope and Limitations

This change does not modify:

- The Strata/external leaderboard API contract.
- Retry delays or HTTP timeout settings.
- ELO calculations.
- Lobby behavior.
- The number of ELO updates performed.

EF normally returns the physical database connection to the ADO.NET pool after each completed command, so this change is not expected to be the sole resolution for connection-pool exhaustion.

one of the  production issues identified separately is that the configured MySQL pool settings were being read but not applied to the connection string. That issue is addressed by the separate database pool configuration PR. --> https://github.com/GeneralsOnlineDevelopmentTeam/Services/pull/39

## Validation

- `dotnet build GenOnlineService/GenOnlineService.csproj`
- Build succeeded with 0 warnings and 0 errors.


This one really aint all that important