### PR TITLE
hotfix: Improve lobby performance

### DIFF
--- a/GenOnlineService/LobbyManager.cs
+++ b/GenOnlineService/LobbyManager.cs
@@ -1285,7 +1285,7 @@ namespace GenOnlineService
 			m_queueLobbiesNeedingDestroyed.Enqueue(lobby);
 		}
 
-		private async Task ProcessLobbiesNeedingDestroyed()
+		public async Task ProcessLobbiesNeedingDestroyed()
 		{
 			while (m_queueLobbiesNeedingDestroyed.TryDequeue(out Lobby? lobbyToDestroy))
 			{
@@ -1365,8 +1365,6 @@ namespace GenOnlineService
 			{
 				await kvPair.Value.Tick();
 			}
-
-			await ProcessLobbiesNeedingDestroyed();
 		}
 
 		public async Task<bool> JoinLobby(AppDbContext _db, Lobby lobby, UserSession playerSession, string strDisplayName, UInt16 userPreferredPort, bool bHasMap)

--- a/GenOnlineService/LobbyManager.cs
+++ b/GenOnlineService/LobbyManager.cs
@@ -389,9 +389,13 @@ namespace GenOnlineService
 				LobbyMember placeholderMember = new LobbyMember(this, null, -1, String.Empty, String.Empty, 0, -1, -1, -1, i < max_players ? EPlayerType.SLOT_OPEN : EPlayerType.SLOT_CLOSED, i, true);
 				Members[i] = placeholderMember;
 			}
-		}
 
-		public event Action<Lobby>? OnLobbyNeedsDestroyed;
+            using var scope = ServiceLocator.Services.CreateScope();
+            var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<AppDbContext>>();
+            _db = factory.CreateDbContext();
+        }
+
+        public event Action<Lobby>? OnLobbyNeedsDestroyed;
 
 		public async Task OnAfterPlayerLeft(Int64 leavingUserID)
 		{
@@ -965,9 +969,10 @@ namespace GenOnlineService
 		private int m_cachedAtStart_numOpen = -1;
 		private int m_cachedAtStart_numClosed = -1;
 		private int m_cachedAtStart_numAI = -1;
+        private AppDbContext _db;
 
-		// TODO: Really, client also shouldnt upload data we arent going to process in this situation, its wasteful
-		public bool WasPVPAtStart()
+        // TODO: Really, client also shouldnt upload data we arent going to process in this situation, its wasteful
+        public bool WasPVPAtStart()
 		{
 			// debug
 #if DEBUG
@@ -1012,10 +1017,7 @@ namespace GenOnlineService
 					try
 					{
 						// create placeholder
-						using var scope = ServiceLocator.Services.CreateScope();
-						var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<AppDbContext>>();
-						await using var db = await factory.CreateDbContextAsync();
-						await Database.MatchHistory.CreatePlaceholderMatchHistory(db, this);
+						await Database.MatchHistory.CreatePlaceholderMatchHistory(_db, this);
 					}
 					catch (Exception ex)
 					{
@@ -1244,13 +1246,18 @@ namespace GenOnlineService
 		private Int64 m_NextLobbyID = 0;
 
 		private readonly IServiceProvider _services;
+		private readonly AppDbContext _db;
 
 		public LobbyManager(IServiceProvider services)
 		{
 			_services = services;
-		}
 
-		public async Task Cleanup()
+            var scope = _services.CreateScope();
+            var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<AppDbContext>>();
+            var _db = factory.CreateDbContext();
+        }
+
+        public async Task Cleanup()
 		{
 			// Remove any lobby that has 0 members and has been around for a bit (enough time for host to join)
 			List<Lobby> lstLobbiesToRemove = new List<Lobby>();
@@ -1553,17 +1560,13 @@ namespace GenOnlineService
 		{
 			try
 			{
-				using var scope = _services.CreateScope();
-				var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<AppDbContext>>();
-				await using var db = await factory.CreateDbContextAsync();
-
 				if (lobby.State != ELobbyState.COMPLETE)
 				{
 					// make done
 					await lobby.UpdateState(ELobbyState.COMPLETE);
 
 					// attempt to commit it
-					await Database.MatchHistory.CommitLobbyToMatchHistory(db, lobby);
+					await Database.MatchHistory.CommitLobbyToMatchHistory(_db, lobby);
 				}
 
 				// delete
@@ -1577,11 +1580,11 @@ namespace GenOnlineService
 					lobby.OnLobbyNeedsDestroyed -= HandleLobbyNeedsDestroyed;
 
 					// make sure we have a winner
-					await Database.MatchHistory.DetermineLobbyWinnerIfNotPresent(db, lobby);
+					await Database.MatchHistory.DetermineLobbyWinnerIfNotPresent(_db, lobby);
 
 					// Post match result to external leaderboard API for every lobby type.
 					// Only QuickMatch responses are expected to carry a ratings body.
-					await ExternalLeaderboardsClient.PostMatchResultAsync(db, lobby);
+					await ExternalLeaderboardsClient.PostMatchResultAsync(_db, lobby);
 				}
 
 				return bRemoved;

--- a/GenOnlineService/Program.cs
+++ b/GenOnlineService/Program.cs
@@ -1268,8 +1268,32 @@ namespace GenOnlineService
 				timerTick.Start();
 			}
 
-			// tick matchmaking (done at lower frequency)
+            // tick lobby cleanup - this is a separate timer to prevent main lobby tick from being blocked by cleanup
+            // @hotfix SkyAero 15/08/2026
 			{
+                System.Timers.Timer timerTick = new System.Timers.Timer(5); // 5ms tick
+                timerTick.AutoReset = false;
+                timerTick.Elapsed += async (sender, e) =>
+                {
+                    try
+                    {
+                        var lobbyManager = ServiceLocator.Services.GetRequiredService<LobbyManager>();
+                        await lobbyManager.ProcessLobbiesNeedingDestroyed();
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"[cleanupTick lobby] Exception: {ex}");
+                    }
+                    finally
+                    {
+                        timerTick.Start();
+                    }
+                };
+                timerTick.Start();
+            }
+
+            // tick matchmaking (done at lower frequency)
+            {
 				System.Timers.Timer timerTick = new System.Timers.Timer(1000); // 1s tick
 				timerTick.AutoReset = false;
 				timerTick.Elapsed += async (sender, e) =>


### PR DESCRIPTION
Possible solution for the server issues of late.
PR consists of two commits, each solving a particular issue.

Commit 1: Move `ProcessLobbbiesNeedingDestroyed()`into its own lobby timer to prevent blocking of `Tick()` actions

The destruction of lobbies involves the processing of game results and statistics, involving multiple database calls. This is a synchronous process and is being awaited by the `Tick()` function. The next `Tick()` event call and update of lobbies does not proceed until `ProcessLobbiesNeedingDestroyed()` has finished.

The hotfix solution is to remove ProcessLobbbiesNeedingDestroyed() from Tick() and creation of a new seperate timer that handles `ProcessLobbbiesNeedingDestroyed()`

Commit 2: Prevent unnecessary creation of AppDbContext

A new `AppDbContext` is created for every `LobbyManager.DeleteLobby()` call and `Lobby.UpdateState` call.
Database contexts should not be recreated for every call, but reused as much as possible.

Hotfix solution is to move the creation of `AppDbContext` to the constructors of `LobbyManager` and `Lobby`.


The implementations have not been tested.