### PR TITLE
fix(leaderboards): (6) move match publication to a durable background queue

### DIFF
--- a/GenOnlineService/Database/Database.MatchHistory.cs
+++ b/GenOnlineService/Database/Database.MatchHistory.cs
@@ -19,7 +19,6 @@
 using GenOnlineService;
 using GenOnlineService.Controllers;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Query;
 using System;
@@ -51,7 +50,6 @@ public class MatchHistoryEntry
 	public uint ExeCRC { get; set; }
 	public uint IniCRC { get; set; }
 	public string? MapPath { get; set; }
-
 	// JSON slots
 	public string? MemberSlot0 { get; set; }
 	public string? MemberSlot1 { get; set; }
@@ -158,6 +156,31 @@ public class MatchHistoryConfiguration : IEntityTypeConfiguration<MatchHistoryEn
 	}
 }
 
+public class ExternalPublicationEntry
+{
+	public long MatchId { get; set; }
+	public DateTime? NextAttemptAt { get; set; }
+	public DateTime? PublishedAt { get; set; }
+	public int Attempts { get; set; }
+	public string? LastError { get; set; }
+}
+
+public class ExternalPublicationConfiguration : IEntityTypeConfiguration<ExternalPublicationEntry>
+{
+	public void Configure(EntityTypeBuilder<ExternalPublicationEntry> entity)
+	{
+		entity.ToTable("external_publication");
+		entity.HasKey(e => e.MatchId);
+		entity.Property(e => e.MatchId).HasColumnName("match_id").ValueGeneratedNever();
+		entity.Property(e => e.NextAttemptAt).HasColumnName("next_attempt_at").HasColumnType("datetime");
+		entity.Property(e => e.PublishedAt).HasColumnName("published_at").HasColumnType("datetime");
+		entity.Property(e => e.Attempts).HasColumnName("attempts").HasDefaultValue(0);
+		entity.Property(e => e.LastError).HasColumnName("last_error").HasMaxLength(512);
+		entity.HasIndex(e => new { e.PublishedAt, e.NextAttemptAt })
+			.HasDatabaseName("ix_external_publication_pending");
+	}
+}
+
 // TODO_EFCORE: put everything in below namespace
 namespace GenOnlineService
 {
@@ -231,6 +254,8 @@ namespace GenOnlineService
 
 namespace Database
 {
+	public readonly record struct ExternalPublicationWorkItem(long MatchId, int Attempt);
+
 	// TODO_EFCORE: Consider moving to zero-serialization model
 	public static class MatchHistory
 	{
@@ -299,7 +324,11 @@ namespace Database
 
 
 
-		private static async Task<string?> _getMemberSlot(AppDbContext db, long matchId, int slotIndex)
+		private static async Task<string?> _getMemberSlot(
+			AppDbContext db,
+			long matchId,
+			int slotIndex,
+			CancellationToken cancellationToken = default)
 		{
 			if (slotIndex < 0 || slotIndex > 7)
 				return null;
@@ -307,7 +336,7 @@ namespace Database
 			return await db.MatchHistory
 				.Where(m => m.MatchId == matchId)
 				.Select(_slotSelectors[slotIndex])
-				.FirstOrDefaultAsync();
+				.FirstOrDefaultAsync(cancellationToken);
 		}
 
 
@@ -576,8 +605,9 @@ namespace Database
 		}
 
 		public static async Task DetermineLobbyWinnerIfNotPresent(
-	AppDbContext db,
-	GenOnlineService.Lobby lobby)
+		AppDbContext db,
+		GenOnlineService.Lobby lobby,
+		CancellationToken cancellationToken = default)
 		{
 			if (lobby == null || lobby.MatchID == 0)
 				return;
@@ -612,7 +642,7 @@ namespace Database
 						if (kv.Value.side == Constants.OBSERVER_SIDE_VALUE)
 							continue;
 
-						await UpdateMatchHistorySetWinFlag(db, lobby.MatchID, kv.Key, false);
+						await UpdateMatchHistorySetWinFlag(db, lobby.MatchID, kv.Key, false, cancellationToken);
 					}
 					return;
 				}
@@ -669,7 +699,7 @@ namespace Database
 							? kv.Value.team == conclusiveWinningTeam.Value
 							: kv.Key == conclusiveWinningSlot;
 
-						await UpdateMatchHistorySetWinFlag(db, lobby.MatchID, kv.Key, isWinner);
+						await UpdateMatchHistorySetWinFlag(db, lobby.MatchID, kv.Key, isWinner, cancellationToken);
 					}
 
 					return;
@@ -749,7 +779,7 @@ namespace Database
 						if (kv.Value.side == Constants.OBSERVER_SIDE_VALUE)
 							continue;
 
-						await UpdateMatchHistorySetWinFlag(db, lobby.MatchID, kv.Key, false);
+						await UpdateMatchHistorySetWinFlag(db, lobby.MatchID, kv.Key, false, cancellationToken);
 					}
 					return;
 				}
@@ -769,21 +799,22 @@ namespace Database
 						(winningTeam != -1 && model.team == winningTeam);
 
 					Console.WriteLine($"[WinnerDet] Match={lobby.MatchID}: marking slot={kv.Key} user={model.user_id} as {(isWinner ? "WINNER" : "loser")}.");
-					await UpdateMatchHistorySetWinFlag(db, lobby.MatchID, kv.Key, isWinner);
+					await UpdateMatchHistorySetWinFlag(db, lobby.MatchID, kv.Key, isWinner, cancellationToken);
 				}
 			}
 			catch (Exception ex)
 			{
 				Console.WriteLine($"[ERROR] DetermineLobbyWinnerIfNotPresent failed: {ex.Message}");
-				SentrySdk.CaptureException(ex);
+				throw;
 			}
 		}
 
 		public static async Task UpdateMatchHistorySetWinFlag(
-	AppDbContext db,
-	ulong matchId,
-	int slotIndex,
-	bool won)
+		AppDbContext db,
+		ulong matchId,
+		int slotIndex,
+		bool won,
+		CancellationToken cancellationToken = default)
 		{
 			if (matchId == 0 || slotIndex < 0 || slotIndex > 7)
 				return;
@@ -791,7 +822,7 @@ namespace Database
 			try
 			{
 				// 1. Load the JSON for this slot
-				string? json = await _getMemberSlot(db, (long)matchId, slotIndex);
+				string? json = await _getMemberSlot(db, (long)matchId, slotIndex, cancellationToken);
 				if (string.IsNullOrEmpty(json))
 					return;
 
@@ -811,14 +842,17 @@ namespace Database
 				var setter = BuildSetter(slotIndex, updatedJson);
 
 				// 6. Execute update (single SQL UPDATE)
-				await db.MatchHistory
+				int updated = await db.MatchHistory
 					.Where(m => m.MatchId == (long)matchId)
-					.ExecuteUpdateAsync(setter);
+					.ExecuteUpdateAsync(setter, cancellationToken);
+
+				if (updated != 1)
+					throw new InvalidOperationException($"Match history entry {matchId} disappeared while its winner was being finalized.");
 			}
 			catch (Exception ex)
 			{
 				Console.WriteLine($"[ERROR] UpdateMatchHistorySetWinFlag failed: {ex.Message}");
-				SentrySdk.CaptureException(ex);
+				throw;
 			}
 		}
 
@@ -994,30 +1028,145 @@ namespace Database
 		}
 
 		// Called when a lobby is deleted, thats the true end of a match
-		public static async Task CommitLobbyToMatchHistory(AppDbContext db, GenOnlineService.Lobby lobby)
+		public static async Task FinalizeAndScheduleExternalPublication(
+			AppDbContext db,
+			GenOnlineService.Lobby lobby,
+			CancellationToken cancellationToken = default)
 		{
 			if (lobby.MatchID == 0)
 				return;
 
-			try
+			await using var transaction = await db.Database.BeginTransactionAsync(cancellationToken);
+
+			await CommitLobbyToMatchHistory(db, lobby, cancellationToken);
+			await DetermineLobbyWinnerIfNotPresent(db, lobby, cancellationToken);
+			await ScheduleExternalPublication(db, lobby.MatchID, cancellationToken);
+
+			await transaction.CommitAsync(cancellationToken);
+		}
+
+		private static async Task CommitLobbyToMatchHistory(
+			AppDbContext db,
+			GenOnlineService.Lobby lobby,
+			CancellationToken cancellationToken)
+		{
+			if (lobby.MatchID == 0)
+				return;
+
+			await db.MatchHistory
+				.Where(m => m.MatchId == (long)lobby.MatchID && !m.Finished)
+				.ExecuteUpdateAsync(s => s
+					.SetProperty(m => m.Finished, true)
+					.SetProperty(m => m.TimeFinished, DateTime.UtcNow), cancellationToken);
+
+			bool matchExists = await db.MatchHistory
+				.AnyAsync(m => m.MatchId == (long)lobby.MatchID && m.Finished, cancellationToken);
+
+			if (!matchExists)
+				throw new InvalidOperationException($"Finished match history entry {lobby.MatchID} was not found.");
+		}
+
+		private static async Task ScheduleExternalPublication(
+			AppDbContext db,
+			ulong matchId,
+			CancellationToken cancellationToken)
+		{
+			if (matchId == 0)
+				return;
+
+			bool exists = await db.ExternalPublications.AnyAsync(p => p.MatchId == (long)matchId, cancellationToken);
+			if (!exists)
 			{
-				await db.MatchHistory
-					.Where(m => m.MatchId == (long)lobby.MatchID && !m.Finished)
-					.ExecuteUpdateAsync(s => s
-						.SetProperty(m => m.Finished, true)
-						.SetProperty(m => m.TimeFinished, DateTime.UtcNow));
+				db.ExternalPublications.Add(new ExternalPublicationEntry
+				{
+					MatchId = (long)matchId,
+					NextAttemptAt = DateTime.UtcNow
+				});
+				await db.SaveChangesAsync(cancellationToken);
 			}
-			catch (Exception ex)
-			{
-				Console.WriteLine($"[ERROR] CommitLobbyToMatchHistory failed: {ex.Message}");
-				SentrySdk.CaptureException(ex);
-			}
+
+			bool publicationIsDurable = await db.MatchHistory.AnyAsync(
+				m => m.MatchId == (long)matchId && m.Finished,
+				cancellationToken);
+			publicationIsDurable &= await db.ExternalPublications.AnyAsync(
+				p => p.MatchId == (long)matchId,
+				cancellationToken);
+
+			if (!publicationIsDurable)
+				throw new InvalidOperationException($"Match history entry {matchId} could not be scheduled for external publication.");
+		}
+
+		public static async Task<List<ExternalPublicationWorkItem>> GetPendingExternalPublications(
+			AppDbContext db,
+			DateTime utcNow,
+			int maxCount,
+			CancellationToken cancellationToken)
+		{
+			List<ExternalPublicationEntry> pending = await db.ExternalPublications
+				.Where(p => p.PublishedAt == null && p.NextAttemptAt != null && p.NextAttemptAt <= utcNow)
+				.OrderBy(p => p.NextAttemptAt)
+				.ThenBy(p => p.MatchId)
+				.Take(maxCount)
+				.ToListAsync(cancellationToken);
+
+			return pending
+				.Select(item => new ExternalPublicationWorkItem(item.MatchId, item.Attempts + 1))
+				.ToList();
+		}
+
+		public static async Task MarkExternalPublicationSucceeded(
+			AppDbContext db,
+			ulong matchId,
+			int attempt,
+			CancellationToken cancellationToken)
+		{
+			if (matchId == 0)
+				throw new ArgumentOutOfRangeException(nameof(matchId));
+
+			int updated = await db.ExternalPublications
+				.Where(p => p.MatchId == (long)matchId && p.PublishedAt == null)
+				.ExecuteUpdateAsync(s => s
+					.SetProperty(p => p.PublishedAt, DateTime.UtcNow)
+					.SetProperty(p => p.NextAttemptAt, (DateTime?)null)
+					.SetProperty(p => p.Attempts, attempt)
+					.SetProperty(p => p.LastError, (string?)null), cancellationToken);
+
+			if (updated != 1)
+				throw new InvalidOperationException($"Match history entry {matchId} could not be acknowledged after external publication.");
+		}
+
+		public static async Task MarkExternalPublicationFailed(
+			AppDbContext db,
+			ulong matchId,
+			int attempt,
+			DateTime? nextAttemptAt,
+			string? errorMessage,
+			CancellationToken cancellationToken)
+		{
+			if (matchId == 0)
+				throw new ArgumentOutOfRangeException(nameof(matchId));
+
+			string? truncatedError = errorMessage;
+			if (!string.IsNullOrEmpty(truncatedError) && truncatedError.Length > 512)
+				truncatedError = truncatedError[..512];
+
+			int updated = await db.ExternalPublications
+				.Where(p => p.MatchId == (long)matchId && p.PublishedAt == null)
+				.ExecuteUpdateAsync(s => s
+					.SetProperty(p => p.NextAttemptAt, nextAttemptAt)
+					.SetProperty(p => p.Attempts, attempt)
+					.SetProperty(p => p.LastError, truncatedError), cancellationToken);
+
+			if (updated != 1)
+				throw new InvalidOperationException($"Match history entry {matchId} could not be rescheduled after publication failure.");
 		}
 
 		internal static async Task<MatchHistory_Entry?> LoadMatchHistoryEntryAsync(
-			AppDbContext db, long matchId)
+			AppDbContext db,
+			long matchId,
+			CancellationToken cancellationToken = default)
 		{
-			var row = await db.MatchHistory.FirstOrDefaultAsync(m => m.MatchId == matchId);
+			var row = await db.MatchHistory.FirstOrDefaultAsync(m => m.MatchId == matchId, cancellationToken);
 			if (row == null)
 				return null;
 

--- a/GenOnlineService/Database/Database.User.cs
+++ b/GenOnlineService/Database/Database.User.cs
@@ -670,7 +670,11 @@ namespace Database
 			}
 		}
 
-		public static async Task SaveELOData(AppDbContext db, long userId, EloData newEloData)
+		public static async Task SaveELOData(
+			AppDbContext db,
+			long userId,
+			EloData newEloData,
+			CancellationToken cancellationToken = default)
 		{
 			try
 			{
@@ -679,14 +683,38 @@ namespace Database
 					.ExecuteUpdateAsync(setters => setters
 						.SetProperty(u => u.EloRating, newEloData.Rating)
 						.SetProperty(u => u.MonthlyEloRating, newEloData.MonthlyRating)
-						.SetProperty(u => u.EloNumberOfMatches, newEloData.NumMatches)
-					);
+						.SetProperty(u => u.EloNumberOfMatches, newEloData.NumMatches),
+						cancellationToken);
+			}
+			catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+			{
+				throw;
 			}
 			catch (Exception ex)
 			{
 				Console.WriteLine($"[ERROR] SaveELOData failed: {ex.Message}");
 				SentrySdk.CaptureException(ex);
 			}
+		}
+
+		public static async Task<bool> SaveExternalELOData(
+			AppDbContext db,
+			long userId,
+			EloData newEloData,
+			CancellationToken cancellationToken = default)
+		{
+			ArgumentNullException.ThrowIfNull(db);
+			ArgumentNullException.ThrowIfNull(newEloData);
+
+			int updated = await db.Users
+				.Where(u => u.ID == userId)
+				.ExecuteUpdateAsync(setters => setters
+					.SetProperty(u => u.EloRating, newEloData.Rating)
+					.SetProperty(u => u.MonthlyEloRating, newEloData.MonthlyRating)
+					.SetProperty(u => u.EloNumberOfMatches, newEloData.NumMatches),
+					cancellationToken);
+
+			return updated == 1;
 		}
 
 	}

--- a/GenOnlineService/Database/Database.cs
+++ b/GenOnlineService/Database/Database.cs
@@ -31,6 +31,7 @@ public class AppDbContext : DbContext
 	public DbSet<ServiceStat> ServiceStats => Set<ServiceStat>();
 	public DbSet<PendingLogin> PendingLogins => Set<PendingLogin>();
 	public DbSet<MatchHistoryEntry> MatchHistory => Set<MatchHistoryEntry>();
+	public DbSet<ExternalPublicationEntry> ExternalPublications => Set<ExternalPublicationEntry>();
 	public DbSet<UserStatsEntry> UserStats => Set<UserStatsEntry>();
 
 	public DbSet<FriendEntry> Friends => Set<FriendEntry>();
@@ -65,6 +66,7 @@ public class AppDbContext : DbContext
 		modelBuilder.ApplyConfiguration(new ServiceStatsConfiguration());
 		modelBuilder.ApplyConfiguration(new PendingLoginConfiguration());
 		modelBuilder.ApplyConfiguration(new MatchHistoryConfiguration());
+		modelBuilder.ApplyConfiguration(new ExternalPublicationConfiguration());
 		modelBuilder.ApplyConfiguration(new UserStatsConfiguration());
 		modelBuilder.ApplyConfiguration(new FriendConfiguration());
 		modelBuilder.ApplyConfiguration(new FriendRequestConfiguration());

--- a/GenOnlineService/Database_Structure/structure.sql
+++ b/GenOnlineService/Database_Structure/structure.sql
@@ -125,6 +125,16 @@ CREATE TABLE IF NOT EXISTS `match_history` (
   PRIMARY KEY (`match_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=563766 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
+CREATE TABLE IF NOT EXISTS `external_publication` (
+  `match_id` bigint(20) NOT NULL,
+  `next_attempt_at` datetime DEFAULT NULL,
+  `published_at` datetime DEFAULT NULL,
+  `attempts` int(11) NOT NULL DEFAULT 0,
+  `last_error` varchar(512) DEFAULT NULL,
+  PRIMARY KEY (`match_id`),
+  KEY `ix_external_publication_pending` (`published_at`,`next_attempt_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
 -- Data exporting was unselected.
 
 -- Dumping structure for table go_production.pending_logins

--- a/GenOnlineService/Database_Structure/upgrade_20260816_external_leaderboard_publication.sql
+++ b/GenOnlineService/Database_Structure/upgrade_20260816_external_leaderboard_publication.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS `external_publication` (
+  `match_id` bigint(20) NOT NULL,
+  `next_attempt_at` datetime DEFAULT NULL,
+  `published_at` datetime DEFAULT NULL,
+  `attempts` int(11) NOT NULL DEFAULT 0,
+  `last_error` varchar(512) DEFAULT NULL,
+  PRIMARY KEY (`match_id`),
+  KEY `ix_external_publication_pending` (`published_at`,`next_attempt_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/GenOnlineService/ExternalLeaderboardPublicationQueue.cs
+++ b/GenOnlineService/ExternalLeaderboardPublicationQueue.cs
@@ -1,0 +1,288 @@
+using GenOnlineService.Controllers;
+using Microsoft.EntityFrameworkCore;
+using System.Net;
+using System.Text.Json;
+
+namespace GenOnlineService
+{
+	public sealed class ExternalLeaderboardPublicationWorker : BackgroundService
+	{
+		private static readonly TimeSpan c_PollInterval = TimeSpan.FromSeconds(1);
+		private static readonly TimeSpan[] c_RetryDelays = new[]
+		{
+			TimeSpan.FromSeconds(2),
+			TimeSpan.FromSeconds(4),
+			TimeSpan.FromSeconds(15),
+			TimeSpan.FromSeconds(30),
+			TimeSpan.FromMinutes(1),
+			TimeSpan.FromMinutes(2),
+			TimeSpan.FromMinutes(2)
+		};
+		private const int c_MaxBatchSize = 8;
+
+		private readonly IDbContextFactory<AppDbContext> _dbFactory;
+
+		public ExternalLeaderboardPublicationWorker(IDbContextFactory<AppDbContext> dbFactory)
+		{
+			_dbFactory = dbFactory;
+		}
+
+		protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+		{
+			while (!stoppingToken.IsCancellationRequested)
+			{
+				try
+				{
+					int processed = await PublishPendingMatches(stoppingToken);
+					if (processed > 0)
+						continue;
+				}
+				catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+				{
+					break;
+				}
+				catch (Exception ex)
+				{
+					Console.WriteLine($"[ERROR] External leaderboard publication poll failed: {ex}");
+					SentrySdk.CaptureException(ex);
+				}
+
+				try
+				{
+					await Task.Delay(c_PollInterval, stoppingToken);
+				}
+				catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+				{
+					break;
+				}
+			}
+		}
+
+		private async Task<int> PublishPendingMatches(CancellationToken stoppingToken)
+		{
+			// This worker is intentionally a single consumer. Use a distributed queue before
+			// running more than one service instance.
+			List<Database.ExternalPublicationWorkItem> pending;
+			await using (AppDbContext db = await _dbFactory.CreateDbContextAsync(stoppingToken))
+			{
+				pending = await Database.MatchHistory.GetPendingExternalPublications(
+					db,
+					DateTime.UtcNow,
+					c_MaxBatchSize,
+					stoppingToken);
+			}
+
+			foreach (Database.ExternalPublicationWorkItem item in pending)
+			{
+				stoppingToken.ThrowIfCancellationRequested();
+
+				try
+				{
+					await PublishItem(item, stoppingToken);
+				}
+				catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+				{
+					throw;
+				}
+				catch (Exception ex)
+				{
+					Console.WriteLine($"[ERROR] External publication bookkeeping failed for match {item.MatchId}: {ex}");
+					SentrySdk.CaptureException(ex);
+					throw;
+				}
+			}
+
+			return pending.Count;
+		}
+
+		private async Task PublishItem(
+			Database.ExternalPublicationWorkItem item,
+			CancellationToken stoppingToken)
+		{
+			try
+			{
+				MatchHistory_Entry? matchEntry;
+				await using (AppDbContext loadDb = await _dbFactory.CreateDbContextAsync(stoppingToken))
+				{
+					matchEntry = await Database.MatchHistory.LoadMatchHistoryEntryAsync(
+						loadDb,
+						item.MatchId,
+						stoppingToken);
+				}
+
+				if (matchEntry == null)
+					throw new InvalidOperationException($"MatchHistory entry not found for match ID {item.MatchId}.");
+
+				string responseBody = await ExternalLeaderboardsClient.PostMatchResultAsync(matchEntry, stoppingToken);
+				try
+				{
+					await ApplyRatingsResponse(matchEntry, responseBody, stoppingToken);
+				}
+				catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+				{
+					throw;
+				}
+				catch (Exception ex)
+				{
+					Console.WriteLine($"[WARNING] Match {item.MatchId} was ingested, but its optional ratings response could not be applied: {ex}");
+					SentrySdk.CaptureException(ex);
+				}
+
+				await using AppDbContext completionDb = await _dbFactory.CreateDbContextAsync(stoppingToken);
+				await Database.MatchHistory.MarkExternalPublicationSucceeded(
+					completionDb,
+					(ulong)item.MatchId,
+					item.Attempt,
+					stoppingToken);
+			}
+			catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+			{
+				throw;
+			}
+			catch (Exception ex)
+			{
+				Console.WriteLine($"[WARNING] Failed to publish match {item.MatchId} to the external leaderboard (attempt {item.Attempt}): {ex.Message}");
+				await RecordFailure(item, ex, stoppingToken);
+			}
+		}
+
+		private async Task ApplyRatingsResponse(
+			MatchHistory_Entry matchEntry,
+			string responseBody,
+			CancellationToken stoppingToken)
+		{
+			long matchId = matchEntry.match_id;
+			if (string.IsNullOrWhiteSpace(responseBody))
+			{
+				if (matchEntry.lobby_type == ELobbyType.QuickMatch)
+					Console.WriteLine($"[WARNING] External Match Ingest response for QuickMatch {matchId} contained no ratings body.");
+				return;
+			}
+
+			EloRefreshResponse? refreshResponse;
+			try
+			{
+				refreshResponse = JsonSerializer.Deserialize<EloRefreshResponse>(responseBody);
+			}
+			catch (JsonException ex)
+			{
+				Console.WriteLine($"[WARNING] External Match Ingest response for match {matchId} could not be deserialized: {ex.Message}");
+				SentrySdk.CaptureException(ex);
+				return;
+			}
+
+			if (refreshResponse?.data == null)
+			{
+				Console.WriteLine($"[WARNING] External Match Ingest response for match {matchId} contained no ratings data.");
+				return;
+			}
+
+			HashSet<long> expectedPlayerIds = matchEntry.members
+				.Where(member => member.HasValue)
+				.Select(member => member.GetValueOrDefault().user_id)
+				.ToHashSet();
+			List<(long UserId, EloData Data)> pendingUpdates = new();
+
+			foreach ((long userId, EloRefreshEntry updatedPlayer) in refreshResponse.data)
+			{
+				if (!expectedPlayerIds.Contains(userId))
+				{
+					Console.WriteLine($"[WARNING] External Match Ingest response for match {matchId} contained unexpected player_id {userId}; skipping (ELO left unchanged).");
+					continue;
+				}
+
+				if (updatedPlayer?.overall == null || updatedPlayer.season == null)
+				{
+					Console.WriteLine($"[WARNING] External Match Ingest response for match {matchId} contained incomplete ratings for player_id {userId}; skipping.");
+					continue;
+				}
+
+				pendingUpdates.Add((
+					userId,
+					new EloData(
+						updatedPlayer.overall.rating,
+						updatedPlayer.season.rating,
+						updatedPlayer.overall.matches)));
+			}
+
+			if (pendingUpdates.Count == 0)
+				return;
+
+			List<(long UserId, EloData Data)> savedUpdates = new(pendingUpdates.Count);
+			await using (AppDbContext db = await _dbFactory.CreateDbContextAsync(stoppingToken))
+			await using (var transaction = await db.Database.BeginTransactionAsync(stoppingToken))
+			{
+				foreach ((long userId, EloData data) in pendingUpdates)
+				{
+					bool saved = await Database.Users.SaveExternalELOData(
+						db,
+						userId,
+						data,
+						stoppingToken);
+
+					if (saved)
+						savedUpdates.Add((userId, data));
+					else
+						Console.WriteLine($"[WARNING] External Match Ingest response for match {matchId} referenced missing user_id {userId}; skipping.");
+				}
+
+				await transaction.CommitAsync(stoppingToken);
+			}
+
+			foreach ((long userId, EloData data) in savedUpdates)
+			{
+				var sharedData = WebSocketManager.GetSharedDataForUser(userId);
+				if (sharedData?.GameStats == null)
+					continue;
+
+				sharedData.GameStats.EloRating = data.Rating;
+				sharedData.GameStats.EloMatches = data.NumMatches;
+				sharedData.GameStats.MonthlyEloRating = data.MonthlyRating;
+			}
+		}
+
+		private async Task RecordFailure(
+			Database.ExternalPublicationWorkItem item,
+			Exception publicationException,
+			CancellationToken stoppingToken)
+		{
+			bool retry = IsRetryable(publicationException) && item.Attempt <= c_RetryDelays.Length;
+			DateTime? nextAttemptAt = retry
+				? DateTime.UtcNow.Add(c_RetryDelays[item.Attempt - 1])
+				: null;
+			await using AppDbContext db = await _dbFactory.CreateDbContextAsync(stoppingToken);
+
+			await Database.MatchHistory.MarkExternalPublicationFailed(
+				db,
+				(ulong)item.MatchId,
+				item.Attempt,
+				nextAttemptAt,
+				publicationException.Message,
+				stoppingToken);
+
+			if (!retry)
+			{
+				Console.WriteLine($"[ERROR] External publication for match {item.MatchId} stopped after {item.Attempt} attempts.");
+				SentrySdk.CaptureException(publicationException);
+			}
+		}
+
+		private static bool IsRetryable(Exception exception)
+		{
+			if (exception is HttpRequestException httpException)
+			{
+				if (httpException.StatusCode is not HttpStatusCode status)
+					return true;
+
+				if ((int)status >= 400 && (int)status < 500)
+					return status is HttpStatusCode.RequestTimeout or HttpStatusCode.TooManyRequests;
+
+				return true;
+			}
+
+			// Database, configuration and other infrastructure failures are retried. Only
+			// explicit permanent HTTP client errors stop immediately.
+			return true;
+		}
+	}
+}

--- a/GenOnlineService/ExternalLeaderboardsClient.cs
+++ b/GenOnlineService/ExternalLeaderboardsClient.cs
@@ -62,7 +62,7 @@ namespace GenOnlineService
             postToken = sectionPostToken;
         }
 
-        private static void GetExternalLeaderboardsGetConfig(out string getUrl, out string getToken)
+        private static void GetExternalLeaderboardsConfig(out string getUrl, out string getToken)
         {
             IConfigurationSection configSection = GetExternalLeaderboardsConfigSection();
 
@@ -166,7 +166,7 @@ namespace GenOnlineService
         {
             try
             {
-                GetExternalLeaderboardsGetConfig(out string getUrl, out string getToken);
+                GetExternalLeaderboardsConfig(out string getUrl, out string getToken);
 
                 string requestUrl = getUrl.Replace("{playerId}", playerId.ToString());
 

--- a/GenOnlineService/ExternalLeaderboardsClient.cs
+++ b/GenOnlineService/ExternalLeaderboardsClient.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -10,20 +9,20 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using GenOnlineService.Controllers;
 using Microsoft.Extensions.Configuration;
-using Polly;
 
 namespace GenOnlineService
 {
     public class EloRefreshResponse
     {
-        public Dictionary<long, EloRefreshEntry> data { get; set; }
+        public Dictionary<long, EloRefreshEntry> data { get; set; } = null!;
     }
 
     public class EloRefreshEntry
     {
-        public EloRefreshRating overall { get; set; }
-        public EloRefreshRating season { get; set; }
+        public EloRefreshRating overall { get; set; } = null!;
+        public EloRefreshRating season { get; set; } = null!;
     }
 
     public class EloRefreshRating
@@ -34,52 +33,49 @@ namespace GenOnlineService
 
     public static class ExternalLeaderboardsClient
     {
-        private static void GetExternalLeaderboardsConfig(out string postUrl, out string getUrl, out string postToken, out string getToken)
+        private static IConfigurationSection GetExternalLeaderboardsConfigSection()
         {
-            postUrl = string.Empty;
-            getUrl = string.Empty;
-            postToken = string.Empty;
-            getToken = string.Empty;
-
             if (Program.g_Config == null)
-            {
                 throw new Exception("Config not loaded");
-            }
 
-            IConfigurationSection? configSection = Program.g_Config.GetSection("ExternalLeaderboards");
-            if (configSection == null)
-            {
+            IConfigurationSection configSection = Program.g_Config.GetSection("ExternalLeaderboards");
+            if (!configSection.Exists())
                 throw new Exception("ExternalLeaderboards section missing in config");
-            }
+
+            return configSection;
+        }
+
+        private static void GetExternalLeaderboardsPostConfig(out string postUrl, out string postToken)
+        {
+            IConfigurationSection configSection = GetExternalLeaderboardsConfigSection();
 
             string? sectionPostUrl = configSection.GetValue<string>("PostUrl");
-            string? sectionGetUrl = configSection.GetValue<string>("GetUrl");
             string? sectionPostToken = configSection.GetValue<string>("PostToken");
-            string? sectionGetToken = configSection.GetValue<string>("GetToken");
 
             if (string.IsNullOrEmpty(sectionPostUrl))
-            {
                 throw new Exception("ExternalLeaderboards PostUrl missing in config");
-            }
-
-            if (string.IsNullOrEmpty(sectionGetUrl))
-            {
-                throw new Exception("ExternalLeaderboards GetUrl missing in config");
-            }
 
             if (string.IsNullOrEmpty(sectionPostToken))
-            {
                 throw new Exception("ExternalLeaderboards PostToken missing in config");
-            }
-
-            if (string.IsNullOrEmpty(sectionGetToken))
-            {
-                throw new Exception("ExternalLeaderboards GetToken missing in config");
-            }
 
             postUrl = sectionPostUrl;
-            getUrl = sectionGetUrl;
             postToken = sectionPostToken;
+        }
+
+        private static void GetExternalLeaderboardsGetConfig(out string getUrl, out string getToken)
+        {
+            IConfigurationSection configSection = GetExternalLeaderboardsConfigSection();
+
+            string? sectionGetUrl = configSection.GetValue<string>("GetUrl");
+            string? sectionGetToken = configSection.GetValue<string>("GetToken");
+
+            if (string.IsNullOrEmpty(sectionGetUrl))
+                throw new Exception("ExternalLeaderboards GetUrl missing in config");
+
+            if (string.IsNullOrEmpty(sectionGetToken))
+                throw new Exception("ExternalLeaderboards GetToken missing in config");
+
+            getUrl = sectionGetUrl;
             getToken = sectionGetToken;
         }
 
@@ -122,126 +118,55 @@ namespace GenOnlineService
             };
         }
 
-        public static async Task PostMatchResultAsync(AppDbContext db, Lobby lobby)
+        public static async Task<string> PostMatchResultAsync(MatchHistory_Entry matchEntry, CancellationToken cancellationToken = default)
         {
-            if (lobby.MatchID == 0)
-                return;
+            ArgumentNullException.ThrowIfNull(matchEntry);
 
-            try
+            long matchID = matchEntry.match_id;
+            if (matchID <= 0)
+                throw new ArgumentOutOfRangeException(nameof(matchEntry), "Match ID must be greater than zero.");
+
+            GetExternalLeaderboardsPostConfig(out string postUrl, out string postToken);
+
+            // The external ingest endpoint must deduplicate repeated submissions by match_id.
+            string payloadJson = JsonSerializer.Serialize(matchEntry);
+
+            string responseBody = string.Empty;
+            HttpClient client = g_LeaderboardsClient.Value;
+
+            using (var request = new HttpRequestMessage(HttpMethod.Post, postUrl))
             {
-                GetExternalLeaderboardsConfig(out string postUrl, out _, out string postToken, out _);
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", postToken);
+                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                request.Content = new StringContent(payloadJson, Encoding.UTF8, "application/json");
 
-                // Load the match payload
-                var matchEntry = await Database.MatchHistory.LoadMatchHistoryEntryAsync(db, (long)lobby.MatchID);
-                if (matchEntry == null)
+                var sw = Stopwatch.StartNew();
+                using (HttpResponseMessage response = await client.SendAsync(request, cancellationToken))
                 {
-                    Console.WriteLine($"[WARNING] MatchHistory entry not found for match ID {lobby.MatchID}");
-                    return;
-                }
+                    sw.Stop();
 
-                // Serialize payload to JSON
-                string payloadJson = JsonSerializer.Serialize(matchEntry);
+                    Console.WriteLine($"[INFO] External Match Ingest POST Response for match {matchID} was received in {sw.ElapsedMilliseconds}ms (status: {response.StatusCode}).");
 
-                // Configure Polly wait-and-retry policy with exponential backoff on HTTP/Socket errors
-                var retryPolicy = Policy
-                    .Handle<HttpRequestException>()
-                    .Or<SocketException>()
-                    .Or<TaskCanceledException>()
-                    .WaitAndRetryAsync(new[]
+                    responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+                    if (!response.IsSuccessStatusCode)
                     {
-                        TimeSpan.FromSeconds(2),
-                        TimeSpan.FromSeconds(4),
-                        TimeSpan.FromSeconds(15),
-                        TimeSpan.FromSeconds(30),
-                        TimeSpan.FromMinutes(1),
-                        TimeSpan.FromMinutes(2),
-                        TimeSpan.FromMinutes(2)
-                    }, (exception, timeSpan, retryCount, context) =>
-                    {
-                        Console.WriteLine($"[WARNING] External Match ingest POST failed (attempt {retryCount}). Retrying in {timeSpan.TotalSeconds}s. Error: {exception.Message}");
-                    });
-
-                HttpResponseMessage? response = null;
-                string? responseBody = null;
-
-                await retryPolicy.ExecuteAsync(async () =>
-                {
-                    HttpClient client = g_LeaderboardsClient.Value;
-
-                    using (var request = new HttpRequestMessage(HttpMethod.Post, postUrl))
-                    {
-                        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", postToken);
-                        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                        request.Content = new StringContent(payloadJson, Encoding.UTF8, "application/json");
-
-                        var sw = Stopwatch.StartNew();
-                        using (response = await client.SendAsync(request))
-                        {
-                            sw.Stop();
-
-                            Console.WriteLine($"[INFO] External Match Ingest POST Response for match {lobby.MatchID} was received in {sw.ElapsedMilliseconds}ms (status: {response.StatusCode}).");
-
-                            // Explicitly verify response success inside execution block to ensure retry triggers on HTTP error statuses
-                            response.EnsureSuccessStatusCode();
-
-                            // NOTE: read the body here, the response is disposed once we leave this block
-                            responseBody = await response.Content.ReadAsStringAsync();
-                        }
+                        string errorBody = responseBody.Length <= 256 ? responseBody : responseBody[..256];
+                        throw new HttpRequestException(
+                            $"External Match Ingest returned {(int)response.StatusCode} ({response.StatusCode}): {errorBody}",
+                            null,
+                            response.StatusCode);
                     }
-                });
-
-                if (responseBody == null)
-                {
-                    Console.WriteLine($"[ERROR] External Match Ingest POST failed for match {lobby.MatchID}.");
-                    return;
-                }
-
-                var refreshResponse = JsonSerializer.Deserialize<EloRefreshResponse>(responseBody);
-                if (refreshResponse?.data == null)
-                {
-                    Console.WriteLine($"[WARNING] External Match Ingest response body contains no data or could not be deserialized: {responseBody}");
-                    return;
-                }
-
-                // Only player IDs that were actually part of this match are valid recipients of an ELO update.
-                var expectedPlayerIds = new HashSet<long>(matchEntry.members.Where(m => m.HasValue).Select(m => m.Value.user_id));
-
-                foreach (var (userId, updatedPlayer) in refreshResponse.data)
-                {
-                    if (!expectedPlayerIds.Contains(userId))
-                    {
-                        Console.WriteLine($"[WARNING] External Match Ingest response for match {lobby.MatchID} contained unexpected player_id {userId}; skipping (ELO left unchanged).");
-                        continue;
-                    }
-
-                    int newRating = updatedPlayer.overall.rating;
-                    int newMatches = updatedPlayer.overall.matches;
-                    int newMonthlyRating = updatedPlayer.season.rating;
-
-                    // Update in-memory session cache if the player is online
-                    var sharedData = WebSocketManager.GetSharedDataForUser(userId);
-                    if (sharedData?.GameStats != null)
-                    {
-                        sharedData.GameStats.EloRating = newRating;
-                        sharedData.GameStats.EloMatches = newMatches;
-                        sharedData.GameStats.MonthlyEloRating = newMonthlyRating;
-                    }
-
-                    // Call SaveELOData to persist as fallback
-                    await Database.Users.SaveELOData(db, userId, new EloData(newRating, newMonthlyRating, newMatches));
                 }
             }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"[ERROR] Exception during External Match Ingest POST: {ex.Message}");
-            }
+
+            return responseBody;
         }
 
         public static async Task<EloData?> GetEloFromApi(long playerId)
         {
             try
             {
-                GetExternalLeaderboardsConfig(out _, out string getUrl, out _, out string getToken);
+                GetExternalLeaderboardsGetConfig(out string getUrl, out string getToken);
 
                 string requestUrl = getUrl.Replace("{playerId}", playerId.ToString());
 

--- a/GenOnlineService/GenOnlineService.csproj
+++ b/GenOnlineService/GenOnlineService.csproj
@@ -48,7 +48,6 @@
     <PackageReference Include="MaxMind.GeoIP2" Version="6.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
     <PackageReference Include="MySqlConnector" Version="2.4.0" />
-    <PackageReference Include="Polly" Version="8.7.0" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
     <PackageReference Include="Sentry" Version="6.8.0" />
   </ItemGroup>

--- a/GenOnlineService/LobbyManager.cs
+++ b/GenOnlineService/LobbyManager.cs
@@ -734,9 +734,6 @@ namespace GenOnlineService
 				Members[i] = placeholderMember;
 			}
 
-            using var scope = ServiceLocator.Services.CreateScope();
-            var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<AppDbContext>>();
-            _db = factory.CreateDbContext();
         }
 
         public event Action<Lobby>? OnLobbyNeedsDestroyed;
@@ -1422,7 +1419,6 @@ public async Task FinalizeACChecks()
 		private int m_cachedAtStart_numOpen = -1;
 		private int m_cachedAtStart_numClosed = -1;
 		private int m_cachedAtStart_numAI = -1;
-        private AppDbContext _db;
 
         // TODO: Really, client also shouldnt upload data we arent going to process in this situation, its wasteful
         public bool WasPVPAtStart()
@@ -1478,7 +1474,10 @@ public async Task FinalizeACChecks()
 					try
 					{
 						// create placeholder
-						await Database.MatchHistory.CreatePlaceholderMatchHistory(_db, this);
+						using var scope = ServiceLocator.Services.CreateScope();
+						var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<AppDbContext>>();
+						await using var db = await factory.CreateDbContextAsync();
+						await Database.MatchHistory.CreatePlaceholderMatchHistory(db, this);
 					}
 					catch (Exception ex)
 					{
@@ -1713,15 +1712,10 @@ public async Task FinalizeACChecks()
 		private Int64 m_NextLobbyID = 0;
 
 		private readonly IServiceProvider _services;
-		private readonly AppDbContext _db;
 
 		public LobbyManager(IServiceProvider services)
 		{
 			_services = services;
-
-            var scope = _services.CreateScope();
-            var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<AppDbContext>>();
-            _db = factory.CreateDbContext();
         }
 
         public async Task Cleanup()
@@ -2021,12 +2015,18 @@ public async Task FinalizeACChecks()
 		{
 			try
 			{
+				using var scope = _services.CreateScope();
+				var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<AppDbContext>>();
+				await using var db = await factory.CreateDbContextAsync();
+
 				if (lobby.State != ELobbyState.COMPLETE)
 				{
 					await lobby.UpdateState(ELobbyState.COMPLETE);
-					await Database.MatchHistory.CommitLobbyToMatchHistory(_db, lobby);
 				}
+				// Persist publication before removing the lobby.
+				await Database.MatchHistory.FinalizeAndScheduleExternalPublication(db, lobby);
 
+				// delete
 				bool bRemoved = m_dictLobbies.Remove(lobby.LobbyID, out _);
 
 				if (bRemoved)
@@ -2034,11 +2034,6 @@ public async Task FinalizeACChecks()
 					WebSocketManager.QueueLobbyListUpdateForViewers(lobby.NetworkRoomID);
 
 					lobby.OnLobbyNeedsDestroyed -= HandleLobbyNeedsDestroyed;
-
-					await Database.MatchHistory.DetermineLobbyWinnerIfNotPresent(_db, lobby);
-
-					// All lobby types are published; only QuickMatch returns ratings.
-					await ExternalLeaderboardsClient.PostMatchResultAsync(_db, lobby);
 				}
 
 				return bRemoved;

--- a/GenOnlineService/Program.cs
+++ b/GenOnlineService/Program.cs
@@ -997,6 +997,7 @@ namespace GenOnlineService
 				g_Discord = new DiscordBot();
 			}
 
+			builder.Services.AddHostedService<ExternalLeaderboardPublicationWorker>();
 			builder.Services.AddSingleton<LobbyManager>();
 
 			var rateLimitingSettings = Program.g_Config.GetSection("RateLimiting");

--- a/README.md
+++ b/README.md
@@ -39,4 +39,5 @@ GeneralsOnline Game Services Code provides RESTful web services which act as a r
 - Build the solution for x64, Windows (or your architecture & OS if different)
 - Edit appsettings.json and fill out any TODO sections (e.g. token settings, database settings)
 - Import the SQL structure to your database (GenOnlineService\Database_Structure\structure.sql)
+- When upgrading an existing database, apply new `GenOnlineService\Database_Structure\upgrade_*.sql` files in date order before starting the updated service
 - Run GenOnlineService.exe


### PR DESCRIPTION
External leaderboard publication previously ran during lobby teardown on the WebSocket processing path. External HTTP latency and retries could therefore delay processing for connected users.

This change records publication work when a match is finalized and processes it asynchronously through a durable database-backed worker.

---

- Finalize match history and schedule external publication in the same database transaction.
- Persist publication attempts, retry time, last error, and completion time in `external_publication`.
- Publish pending matches from a background worker with persisted retry backoff.
- Stop retrying permanent client errors while retaining retries for transient failures.
- Keep EF Core contexts scoped to individual database operations; no context is held during external HTTP.
- Separate publication transport from persistence: the external client only sends the match and returns the response, while the worker owns database and session-cache updates.
- Save rating updates to the database before updating the local session cache.
- Treat rating-response processing as best effort so it cannot retry an already successful ingest.
- Remove Polly because retry state is now handled durably by the worker.

---

Apply `upgrade_20260816_external_leaderboard_publication.sql` before deploying the updated service.

The worker currently assumes a single service instance.