### PR TITLE
fix(ws): make the GeoIP database optional so a fresh clone starts

### DIFF
--- a/GenOnlineService/Controllers/WebSocket/WebSocketController.cs
+++ b/GenOnlineService/Controllers/WebSocket/WebSocketController.cs
@@ -47,8 +47,23 @@ namespace GenOnlineService.Controllers
 			AllowOutOfOrderMetadataProperties = true
 		};
 
-		// GeoIP DB is designed to be reused; opening per request is expensive
-		private static readonly DatabaseReader GeoIpReader = new("data/GeoLite2-City.mmdb");
+		// GeoIP DB is designed to be reused; opening per request is expensive.
+		// It is gitignored and absent in fresh clones, so a failure to open must
+		// fall back to the lookup defaults rather than fail static init.
+		private static readonly DatabaseReader? GeoIpReader = TryOpenGeoIp();
+
+		private static DatabaseReader? TryOpenGeoIp()
+		{
+			try
+			{
+				return new DatabaseReader("data/GeoLite2-City.mmdb");
+			}
+			catch (Exception ex)
+			{
+				Console.WriteLine($"[WS] GeoIP DB unavailable ({ex.Message}); using fallback coordinates");
+				return null;
+			}
+		}
 
 		private struct WSMessageEnvelope
 		{
@@ -86,19 +101,22 @@ namespace GenOnlineService.Controllers
 
 			try
 			{
-				var city = GeoIpReader.City(ipAddress);
-
-				ipContinent = city.Continent.Code;
-				ipCountry = city.Country.IsoCode;
-
-				if (city.Location.Longitude != null)
+				if (GeoIpReader != null)
 				{
-					dLongitude = (double)city.Location.Longitude;
-				}
+					var city = GeoIpReader.City(ipAddress);
 
-				if (city.Location.Latitude != null)
-				{
-					dLatitude = (double)city.Location.Latitude;
+					ipContinent = city.Continent.Code;
+					ipCountry = city.Country.IsoCode;
+
+					if (city.Location.Longitude != null)
+					{
+						dLongitude = (double)city.Location.Longitude;
+					}
+
+					if (city.Location.Latitude != null)
+					{
+						dLatitude = (double)city.Location.Latitude;
+					}
 				}
 			}
 			catch


### PR DESCRIPTION
## Description

The GeoLite2-City.mmdb is gitignored and absent in a fresh clone, but DatabaseReader was opened in a static initialiser of WebSocketController. A fresh checkout therefore failed static init and the server crashed on startup before a single request could be served.

This makes the database optional: opening it is wrapped in a 	ry/catch, and when the file is missing the lookup falls back to the existing default coordinates (the same defaults the code already used for a lookup failure).

No behaviour change when the .mmdb is present.

Split out of #43 at the reviewer's request.