### PR TITLE
chore(deps): (7) clean up database and cryptography dependencies

### DIFF
--- a/GenOnlineService/Constants.cs
+++ b/GenOnlineService/Constants.cs
@@ -20,8 +20,6 @@ using Amazon.S3;
 using Amazon.S3.Model;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.EntityFrameworkCore;
-using MySqlX.XDevAPI;
-using Org.BouncyCastle.Tls;
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics.Metrics;
@@ -33,7 +31,6 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using ZstdSharp.Unsafe;
 
 namespace GenOnlineService
 {

--- a/GenOnlineService/Controllers/CheckLogin/CheckLoginController.cs
+++ b/GenOnlineService/Controllers/CheckLogin/CheckLoginController.cs
@@ -19,7 +19,6 @@
 using Database;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using MySqlX.XDevAPI.Common;
 using System;
 using System.Net;
 using System.Security.Cryptography;

--- a/GenOnlineService/Controllers/LoginCode/LoginCodeController.cs
+++ b/GenOnlineService/Controllers/LoginCode/LoginCodeController.cs
@@ -20,7 +20,6 @@ using GenOnlineService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using MySqlX.XDevAPI.Common;
 using System;
 using System.Collections.Concurrent;
 using System.Net;

--- a/GenOnlineService/Controllers/LoginWithToken/LoginWithTokenController.cs
+++ b/GenOnlineService/Controllers/LoginWithToken/LoginWithTokenController.cs
@@ -19,7 +19,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using MySqlX.XDevAPI.Common;
 using System;
 using System.Net;
 using System.Security.Cryptography;

--- a/GenOnlineService/Controllers/Matchmaking/MatchmakingController.cs
+++ b/GenOnlineService/Controllers/Matchmaking/MatchmakingController.cs
@@ -22,8 +22,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using MySqlX.XDevAPI.Common;
-using Org.BouncyCastle.Tls;
 using System;
 using System.Net;
 using System.Net.WebSockets;

--- a/GenOnlineService/Controllers/Monitoring/MonitoringController.cs
+++ b/GenOnlineService/Controllers/Monitoring/MonitoringController.cs
@@ -21,7 +21,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
-using Org.BouncyCastle.Security;
 using System;
 using System.Collections.Concurrent;
 using System.Net;

--- a/GenOnlineService/Controllers/OID/OIDController.cs
+++ b/GenOnlineService/Controllers/OID/OIDController.cs
@@ -20,7 +20,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
-using MySqlX.XDevAPI.Common;
 using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net;

--- a/GenOnlineService/Discord.cs
+++ b/GenOnlineService/Discord.cs
@@ -23,7 +23,6 @@ using Discord;
 using Discord.Rest;
 using Discord.WebSocket;
 using GenOnlineService;
-using MySqlX.XDevAPI;
 using System;
 using System.Collections.Generic;
 using System.Net.WebSockets;

--- a/GenOnlineService/GenOnlineService.csproj
+++ b/GenOnlineService/GenOnlineService.csproj
@@ -47,8 +47,7 @@
     <PackageReference Include="Discord.Net" Version="3.20.1" />
     <PackageReference Include="MaxMind.GeoIP2" Version="6.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
-    <PackageReference Include="MySql.Data" Version="9.7.0" />
-    <PackageReference Include="NSec.Cryptography" Version="26.4.0" />
+    <PackageReference Include="MySqlConnector" Version="2.4.0" />
     <PackageReference Include="Polly" Version="8.7.0" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
     <PackageReference Include="Sentry" Version="6.8.0" />

--- a/GenOnlineService/LobbyManager.cs
+++ b/GenOnlineService/LobbyManager.cs
@@ -20,7 +20,6 @@ using Amazon.S3.Model;
 using Discord;
 using GenOnlineService.Controllers;
 using Microsoft.EntityFrameworkCore;
-using MySqlX.XDevAPI;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/GenOnlineService/MatchmakingManager.cs
+++ b/GenOnlineService/MatchmakingManager.cs
@@ -24,7 +24,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
-using Org.BouncyCastle.Tls;
 using System;
 using System.Collections.Concurrent;
 using System.Net;

--- a/GenOnlineService/Program.cs
+++ b/GenOnlineService/Program.cs
@@ -16,7 +16,6 @@
 **    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-using Google.Protobuf.WellKnownTypes;
 using MaxMind.GeoIP2;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -30,10 +29,6 @@ using Microsoft.AspNetCore.WebSockets;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
-using Org.BouncyCastle.Crypto;
-using Org.BouncyCastle.OpenSsl;
-using Org.BouncyCastle.Pkcs;
-using Org.BouncyCastle.Security;
 using Sentry;
 using System.Collections.Concurrent;
 using System.Configuration;
@@ -187,37 +182,6 @@ namespace GenOnlineService
 			return false;
 		}
 	}
-	public static class CertHelpers
-	{
-		public static X509Certificate2 LoadPemWithPrivateKey(string certPath, string keyPath)
-		{
-			using (var certReader = new StreamReader(certPath))
-			using (var keyReader = new StreamReader(keyPath))
-			{
-				var pemCertReader = new PemReader(certReader);
-				var pemKeyReader = new PemReader(keyReader);
-
-				var certificate = (Org.BouncyCastle.X509.X509Certificate)pemCertReader.ReadObject();
-				var privateKey = (AsymmetricKeyParameter)pemKeyReader.ReadObject();
-
-				//var store = new Pkcs12Store();
-				var store = new Pkcs12StoreBuilder().Build(); // Fix for CS1729  
-				var certEntry = new X509CertificateEntry(certificate);
-				store.SetCertificateEntry("cert", certEntry);
-				store.SetKeyEntry("key", new AsymmetricKeyEntry(privateKey), new[] { certEntry });
-
-				using (var ms = new MemoryStream())
-				{
-					store.Save(ms, new char[0], new SecureRandom());
-#pragma warning disable SYSLIB0057 // Type or member is obsolete
-					return new X509Certificate2(ms.ToArray(), string.Empty);
-#pragma warning restore SYSLIB0057 // Type or member is obsolete
-				}
-			}
-		}
-	}
-
-
 	public class BasicAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
 	{
 		public BasicAuthenticationHandler(
@@ -439,7 +403,7 @@ namespace GenOnlineService
 			string? password = dbSettings.GetValue<string>("db_password");
 			UInt16? port = dbSettings.GetValue<UInt16>("db_port");
 
-			// Fall back to MySql.Data's own defaults when a key is absent, rather than silently
+			// Fall back to MySqlConnector's own defaults when a key is absent, rather than silently
 			// disabling pooling / zeroing the pool size for deployments predating these settings.
 			int db_min_poolsize = dbSettings.GetValue<int?>("db_min_poolsize") ?? 0;
 			int db_max_poolsize = dbSettings.GetValue<int?>("db_max_poolsize") ?? 100;
@@ -483,7 +447,7 @@ namespace GenOnlineService
 			{
 				//var builder = WebApplication.CreateBuilder(args);
 
-				var csb = new MySql.Data.MySqlClient.MySqlConnectionStringBuilder
+				var csb = new MySqlConnector.MySqlConnectionStringBuilder
 				{
 					Server = hostname,
 					Port = (uint)port,
@@ -492,7 +456,7 @@ namespace GenOnlineService
 					Password = password,
 					ConnectionTimeout = (uint)db_connect_timeout,
 					DefaultCommandTimeout = (uint)db_command_timeout,
-					SslMode = MySql.Data.MySqlClient.MySqlSslMode.Preferred,
+					SslMode = MySqlConnector.MySqlSslMode.Preferred,
 					Pooling = db_use_pooling,
 					MinimumPoolSize = (uint)db_min_poolsize,
 					MaximumPoolSize = (uint)db_max_poolsize,
@@ -1255,8 +1219,6 @@ namespace GenOnlineService
 				}
 				else
 				{
-					//X509Certificate2 = CertHelpers.LoadPemWithPrivateKey(cert_pem_path, cert_key_path);
-
 					X509Certificate2 = X509Certificate2.CreateFromPemFile(cert_pem_path, cert_key_path);
 
 


### PR DESCRIPTION
- Use `MySqlConnector` directly for connection-string construction
- Remove `MySql.Data` and unused X DevAPI imports
- Remove the unused `NSec.Cryptography` dependency
- Remove the dead BouncyCastle PEM certificate helper
- Remove other stale imports associated with unused dependencies

The existing .NET PEM certificate-loading path remains unchanged.