### PR TITLE
feat(networking): (8) add proxy-aware origin handling

### DIFF
--- a/GenOnlineService/Controllers/CheckLogin/CheckLoginController.cs
+++ b/GenOnlineService/Controllers/CheckLogin/CheckLoginController.cs
@@ -58,7 +58,9 @@ namespace GenOnlineService.Controllers
 
 		[HttpPost]
 		//public async Task<APIResult> Post([FromHeader(Name = "CF-Connecting-IP")] string? ipAddress)
-		public async Task<APIResult> Post()
+		public async Task<APIResult> Post(
+			[FromRoute] string environment,
+			[FromRoute(Name = "contract_version")] string contractVersion)
 		{
 			using (var reader = new StreamReader(HttpContext.Request.Body))
 			{
@@ -67,7 +69,7 @@ namespace GenOnlineService.Controllers
 				POST_CheckLogin_Result result = (POST_CheckLogin_Result)await Post_InternalHandler(
 					jsonData,
 					IPHelpers.NormalizeIP(HttpContext.Connection.RemoteIpAddress?.ToString()),
-					Program.BuildWebSocketUrl(Request));
+					Program.BuildWebSocketUrl(Request, environment, contractVersion));
 				return result;
 			}
 		}

--- a/GenOnlineService/Controllers/CheckLogin/CheckLoginController.cs
+++ b/GenOnlineService/Controllers/CheckLogin/CheckLoginController.cs
@@ -64,18 +64,15 @@ namespace GenOnlineService.Controllers
 			{
 				string jsonData = await reader.ReadToEndAsync();
 
-				bool bSecureWS = true;
-				//if (ipCountry2LISO.ToLower() == "ru")
-				{
-					//bSecureWS = false;
-				}
-
-				POST_CheckLogin_Result result = (POST_CheckLogin_Result)await Post_InternalHandler(jsonData, IPHelpers.NormalizeIP(HttpContext.Connection.RemoteIpAddress?.ToString()), bSecureWS);
+				POST_CheckLogin_Result result = (POST_CheckLogin_Result)await Post_InternalHandler(
+					jsonData,
+					IPHelpers.NormalizeIP(HttpContext.Connection.RemoteIpAddress?.ToString()),
+					Program.BuildWebSocketUrl(Request));
 				return result;
 			}
 		}
 
-		public async Task<APIResult> Post_InternalHandler(string jsonData, string ipAddr, bool bSecureWS, bool bIsMonitor = false)
+		public async Task<APIResult> Post_InternalHandler(string jsonData, string ipAddr, string webSocketUrl, bool bIsMonitor = false)
 		{
 			POST_CheckLogin_Result result = new POST_CheckLogin_Result();
 
@@ -218,7 +215,7 @@ namespace GenOnlineService.Controllers
 											result.refresh_token = refreshtoken;
 											result.user_id = user_id;
 											result.display_name = strDisplayName;
-											result.ws_uri = Program.GetWebSocketAddress(bSecureWS);
+											result.ws_uri = webSocketUrl;
 
 											// clear cached data, its a new session and the client reconnects its
 											// websocket using the ws_uri below - must be awaited so the teardown

--- a/GenOnlineService/Controllers/LoginWithToken/LoginWithTokenController.cs
+++ b/GenOnlineService/Controllers/LoginWithToken/LoginWithTokenController.cs
@@ -66,18 +66,15 @@ namespace GenOnlineService.Controllers.LoginWithToken
 			{
 				string jsonData = await reader.ReadToEndAsync();
 
-				bool bSecureWS = true;
-				//if (ipCountry2LISO.ToLower() == "ru")
-				{
-					//bSecureWS = false;
-				}
-
-				POST_LoginWithToken_Result result = (POST_LoginWithToken_Result)await Post_InternalHandler(jsonData, IPHelpers.NormalizeIP(HttpContext.Connection.RemoteIpAddress?.ToString()), bSecureWS);
+				POST_LoginWithToken_Result result = (POST_LoginWithToken_Result)await Post_InternalHandler(
+					jsonData,
+					IPHelpers.NormalizeIP(HttpContext.Connection.RemoteIpAddress?.ToString()),
+					Program.BuildWebSocketUrl(Request));
 				return result;
 			}
 		}
 
-		public async Task<APIResult> Post_InternalHandler(string jsonData, string ipAddr, bool bSecureWS, bool bWasMonitor = false)
+		public async Task<APIResult> Post_InternalHandler(string jsonData, string ipAddr, string webSocketUrl, bool bWasMonitor = false)
 		{
 			if (bWasMonitor)
 			{
@@ -164,7 +161,7 @@ namespace GenOnlineService.Controllers.LoginWithToken
 						result.user_id = user_id;
 						result.display_name = strDisplayName;
 
-						result.ws_uri = Program.GetWebSocketAddress(bSecureWS);
+						result.ws_uri = webSocketUrl;
 
 						// This endpoint re-establishes a session, so tear down any state the previous
 						// one left behind (lobby membership, matchmaking, cached session data). Must

--- a/GenOnlineService/Controllers/LoginWithToken/LoginWithTokenController.cs
+++ b/GenOnlineService/Controllers/LoginWithToken/LoginWithTokenController.cs
@@ -60,7 +60,9 @@ namespace GenOnlineService.Controllers.LoginWithToken
 
 		[HttpPost(Name = "PostLoginWithToken")]
 		//public async Task<APIResult> Post([FromHeader(Name = "CF-Connecting-IP")] string? ipAddress)
-		public async Task<APIResult> Post()
+		public async Task<APIResult> Post(
+			[FromRoute] string environment,
+			[FromRoute(Name = "contract_version")] string contractVersion)
 		{
 			using (var reader = new StreamReader(HttpContext.Request.Body))
 			{
@@ -69,7 +71,7 @@ namespace GenOnlineService.Controllers.LoginWithToken
 				POST_LoginWithToken_Result result = (POST_LoginWithToken_Result)await Post_InternalHandler(
 					jsonData,
 					IPHelpers.NormalizeIP(HttpContext.Connection.RemoteIpAddress?.ToString()),
-					Program.BuildWebSocketUrl(Request));
+					Program.BuildWebSocketUrl(Request, environment, contractVersion));
 				return result;
 			}
 		}

--- a/GenOnlineService/Controllers/Monitoring/MonitoringController.cs
+++ b/GenOnlineService/Controllers/Monitoring/MonitoringController.cs
@@ -224,7 +224,7 @@ namespace GenOnlineService.Controllers
 					var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<AppDbContext>>();
 
 					GenOnlineService.Controllers.LoginWithToken.LoginWithToken loginWithTokenController = new GenOnlineService.Controllers.LoginWithToken.LoginWithToken(factory);
-					GenOnlineService.Controllers.LoginWithToken.POST_LoginWithToken_Result internalResult = (GenOnlineService.Controllers.LoginWithToken.POST_LoginWithToken_Result)await loginWithTokenController.Post_InternalHandler("{\"challenge\": \"abc\", \"token\": \"iamatest\", \"client_id\": \"gen_online_60hz\"}", IPAddress.Loopback.ToString(), true);
+					GenOnlineService.Controllers.LoginWithToken.POST_LoginWithToken_Result internalResult = (GenOnlineService.Controllers.LoginWithToken.POST_LoginWithToken_Result)await loginWithTokenController.Post_InternalHandler("{\"challenge\": \"abc\", \"token\": \"iamatest\", \"client_id\": \"gen_online_60hz\"}", IPAddress.Loopback.ToString(), Program.BuildWebSocketUrl(Request));
 					return internalResult;
 				}
 				catch
@@ -302,7 +302,7 @@ namespace GenOnlineService.Controllers
 				try
 				{
 					GenOnlineService.Controllers.CheckLoginController checkLoginController = new GenOnlineService.Controllers.CheckLoginController(_dbFactory);
-					APIResult internalResult = await checkLoginController.Post_InternalHandler("{\"challenge\": \"abc\", \"nonce\": \"def\", \"code\": \"iamatest\", \"client_id\": \"gen_online_30hz\"}", IPAddress.Loopback.ToString(), true);
+					APIResult internalResult = await checkLoginController.Post_InternalHandler("{\"challenge\": \"abc\", \"nonce\": \"def\", \"code\": \"iamatest\", \"client_id\": \"gen_online_30hz\"}", IPAddress.Loopback.ToString(), Program.BuildWebSocketUrl(Request));
 					return internalResult;
 				}
 				catch

--- a/GenOnlineService/Controllers/Monitoring/MonitoringController.cs
+++ b/GenOnlineService/Controllers/Monitoring/MonitoringController.cs
@@ -209,7 +209,9 @@ namespace GenOnlineService.Controllers
 		[Route("LoginWithToken")]
 		[Authorize(Roles = "Monitor")]
 		[HttpGet]
-		public async Task<APIResult?> Monitor_LoginWithToken()
+		public async Task<APIResult?> Monitor_LoginWithToken(
+			[FromRoute] string environment,
+			[FromRoute(Name = "contract_version")] string contractVersion)
 		{
 			if (!this.User.IsInRole("Monitor"))
 			{
@@ -224,7 +226,7 @@ namespace GenOnlineService.Controllers
 					var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<AppDbContext>>();
 
 					GenOnlineService.Controllers.LoginWithToken.LoginWithToken loginWithTokenController = new GenOnlineService.Controllers.LoginWithToken.LoginWithToken(factory);
-					GenOnlineService.Controllers.LoginWithToken.POST_LoginWithToken_Result internalResult = (GenOnlineService.Controllers.LoginWithToken.POST_LoginWithToken_Result)await loginWithTokenController.Post_InternalHandler("{\"challenge\": \"abc\", \"token\": \"iamatest\", \"client_id\": \"gen_online_60hz\"}", IPAddress.Loopback.ToString(), Program.BuildWebSocketUrl(Request));
+					GenOnlineService.Controllers.LoginWithToken.POST_LoginWithToken_Result internalResult = (GenOnlineService.Controllers.LoginWithToken.POST_LoginWithToken_Result)await loginWithTokenController.Post_InternalHandler("{\"challenge\": \"abc\", \"token\": \"iamatest\", \"client_id\": \"gen_online_60hz\"}", IPAddress.Loopback.ToString(), Program.BuildWebSocketUrl(Request, environment, contractVersion));
 					return internalResult;
 				}
 				catch
@@ -291,7 +293,9 @@ namespace GenOnlineService.Controllers
 		[Route("CheckLogin")]
 		[Authorize(Roles = "Monitor")]
 		[HttpGet]
-		public async Task<APIResult?> Monitor_CheckLogin()
+		public async Task<APIResult?> Monitor_CheckLogin(
+			[FromRoute] string environment,
+			[FromRoute(Name = "contract_version")] string contractVersion)
 		{
 			if (!this.User.IsInRole("Monitor"))
 			{
@@ -302,7 +306,7 @@ namespace GenOnlineService.Controllers
 				try
 				{
 					GenOnlineService.Controllers.CheckLoginController checkLoginController = new GenOnlineService.Controllers.CheckLoginController(_dbFactory);
-					APIResult internalResult = await checkLoginController.Post_InternalHandler("{\"challenge\": \"abc\", \"nonce\": \"def\", \"code\": \"iamatest\", \"client_id\": \"gen_online_30hz\"}", IPAddress.Loopback.ToString(), Program.BuildWebSocketUrl(Request));
+					APIResult internalResult = await checkLoginController.Post_InternalHandler("{\"challenge\": \"abc\", \"nonce\": \"def\", \"code\": \"iamatest\", \"client_id\": \"gen_online_30hz\"}", IPAddress.Loopback.ToString(), Program.BuildWebSocketUrl(Request, environment, contractVersion));
 					return internalResult;
 				}
 				catch

--- a/GenOnlineService/Controllers/WebSocket/WebSocketController.cs
+++ b/GenOnlineService/Controllers/WebSocket/WebSocketController.cs
@@ -70,6 +70,8 @@ namespace GenOnlineService.Controllers
 			public int msg_id { get; set; }
 		}
 
+		[Route("/env/{environment}/contract/{contract_version}/ws")]
+		// TODO: Remove the unscoped route after existing clients have migrated.
 		[Route("/ws")]
 		[Authorize(Roles = "GameClient,ChatClient,GameLauncher")]
 		public async Task Get([FromHeader(Name = "is-reconnect")] bool bIsReconnect)

--- a/GenOnlineService/Program.cs
+++ b/GenOnlineService/Program.cs
@@ -896,7 +896,7 @@ namespace GenOnlineService
 			return true;
 		}
 
-		public static string BuildWebSocketUrl(HttpRequest request)
+		public static string BuildWebSocketUrl(HttpRequest request, string environment, string contractVersion)
 		{
 			string webSocketScheme;
 			if (request.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
@@ -917,7 +917,11 @@ namespace GenOnlineService
 				throw new InvalidOperationException("Cannot build a WebSocket URL because the request Host is empty.");
 			}
 
-			return UriHelper.BuildAbsolute(webSocketScheme, request.Host, request.PathBase, new PathString("/ws"));
+			return UriHelper.BuildAbsolute(
+				webSocketScheme,
+				request.Host,
+				request.PathBase,
+				new PathString($"/env/{Uri.EscapeDataString(environment)}/contract/{Uri.EscapeDataString(contractVersion)}/ws"));
 		}
 
 		public static async Task Main(string[] args)

--- a/GenOnlineService/Program.cs
+++ b/GenOnlineService/Program.cs
@@ -20,7 +20,10 @@ using Google.Protobuf.WellKnownTypes;
 using MaxMind.GeoIP2;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.WebSockets;
@@ -36,6 +39,7 @@ using System.Collections.Concurrent;
 using System.Configuration;
 using System.Drawing;
 using System.IdentityModel.Tokens.Jwt;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Net.WebSockets;
 using System.Security.Claims;
@@ -789,31 +793,131 @@ namespace GenOnlineService
 			}
 		}
 
-		public static string GetWebSocketAddress(bool bSecure)
+		private static CorsPolicy BuildCorsPolicy(IConfiguration configuration)
 		{
-			if (Program.g_Config == null)
+			string[] configuredOrigins = configuration
+				.GetSection("AllowedOrigins")
+				.Get<string[]>() ?? Array.Empty<string>();
+
+			string[] allowedOrigins = configuredOrigins
+				.Select(origin => origin.Trim())
+				.Where(origin => origin.Length > 0)
+				.Distinct(StringComparer.OrdinalIgnoreCase)
+				.ToArray();
+
+			bool allowAnyOrigin = allowedOrigins.Contains("*");
+			if (allowAnyOrigin && allowedOrigins.Length > 1)
 			{
-				throw new Exception("g_Config is null.");
+				throw new InvalidOperationException("AllowedOrigins cannot combine '*' with explicit origins.");
 			}
 
-			IConfiguration? coreSettings = Program.g_Config.GetSection("Core");
+			var policyBuilder = new CorsPolicyBuilder()
+				.AllowAnyHeader()
+				.AllowAnyMethod();
 
-			if (coreSettings == null)
+			if (allowAnyOrigin)
 			{
-				throw new Exception("Core section of config is null.");
+				// CORS forbids combining any-origin with credential sharing.
+				policyBuilder.AllowAnyOrigin();
+			}
+			else if (allowedOrigins.Length > 0)
+			{
+				policyBuilder.WithOrigins(allowedOrigins)
+					.SetIsOriginAllowedToAllowWildcardSubdomains()
+					.AllowCredentials();
 			}
 
+			return policyBuilder.Build();
+		}
 
-			string configKey = bSecure ? "ws_address" : "ws_address_insecure";
+		private static bool TryConfigureForwardedHeaders(IServiceCollection services, IConfiguration configuration)
+		{
+			string[] trustedProxyValues = (configuration.GetSection("TrustedProxies").Get<string[]>() ?? Array.Empty<string>())
+				.Where(value => !string.IsNullOrWhiteSpace(value))
+				.Select(value => value.Trim())
+				.Distinct(StringComparer.OrdinalIgnoreCase)
+				.ToArray();
 
-			string? ws_address = coreSettings.GetValue<string>(configKey);
-
-			if (ws_address == null)
+			if (trustedProxyValues.Length == 0)
 			{
-				throw new Exception(String.Format("{0} in Core section of config is null.", configKey));
+				return false;
 			}
 
-			return ws_address;
+			bool trustAnyProxy = trustedProxyValues.Contains("*");
+			if (trustAnyProxy && trustedProxyValues.Length > 1)
+			{
+				throw new InvalidOperationException("TrustedProxies cannot combine '*' with IP addresses or CIDR networks.");
+			}
+
+			var trustedProxyAddresses = new List<IPAddress>();
+			var trustedProxyNetworks = new List<System.Net.IPNetwork>();
+
+			foreach (string value in trustedProxyValues.Where(value => value != "*"))
+			{
+				if (IPAddress.TryParse(value, out IPAddress? address))
+				{
+					trustedProxyAddresses.Add(address);
+				}
+				else if (System.Net.IPNetwork.TryParse(value, out System.Net.IPNetwork network))
+				{
+					trustedProxyNetworks.Add(network);
+				}
+				else
+				{
+					throw new InvalidOperationException($"TrustedProxies contains invalid IP address or CIDR network '{value}'.");
+				}
+			}
+
+			services.Configure<ForwardedHeadersOptions>(options =>
+			{
+				options.ForwardedHeaders = ForwardedHeaders.XForwardedFor
+					| ForwardedHeaders.XForwardedProto
+					| ForwardedHeaders.XForwardedHost
+					| ForwardedHeaders.XForwardedPrefix;
+				options.KnownProxies.Clear();
+				options.KnownIPNetworks.Clear();
+
+				if (trustAnyProxy)
+				{
+					return;
+				}
+
+				foreach (IPAddress trustedProxyAddress in trustedProxyAddresses)
+				{
+					options.KnownProxies.Add(trustedProxyAddress);
+				}
+
+				foreach (System.Net.IPNetwork trustedProxyNetwork in trustedProxyNetworks)
+				{
+					options.KnownIPNetworks.Add(trustedProxyNetwork);
+				}
+			});
+
+			return true;
+		}
+
+		public static string BuildWebSocketUrl(HttpRequest request)
+		{
+			string webSocketScheme;
+			if (request.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
+			{
+				webSocketScheme = "wss";
+			}
+			else if (request.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase))
+			{
+				webSocketScheme = "ws";
+			}
+			else
+			{
+				throw new InvalidOperationException($"Cannot build a WebSocket URL from request scheme '{request.Scheme}'.");
+			}
+
+			if (!request.Host.HasValue)
+			{
+				throw new InvalidOperationException("Cannot build a WebSocket URL because the request Host is empty.");
+			}
+
+			return UriHelper.BuildAbsolute(webSocketScheme, request.Host, request.PathBase, new PathString("/ws"));
 		}
 
 		public static async Task Main(string[] args)
@@ -830,6 +934,10 @@ namespace GenOnlineService
 			// Add services to the container.
 
 			g_Config = builder.Configuration;
+
+			// Process the original client IP, request scheme, and host only when
+			// one or more trusted reverse proxies are configured.
+			bool useForwardedHeaders = TryConfigureForwardedHeaders(builder.Services, builder.Configuration);
 
 			ShowLogo();
 
@@ -924,19 +1032,11 @@ namespace GenOnlineService
 				});
 			}
 
+			CorsPolicy corsPolicy = BuildCorsPolicy(builder.Configuration);
+
 			builder.Services.AddCors(options =>
 			{
-				options.AddDefaultPolicy(policy =>
-				{
-					policy.WithOrigins(
-						"https://localhost:9000",
-						"http://localhost:9001",
-						"https://*.playgenerals.online"
-					)
-					.AllowAnyHeader()
-					.AllowAnyMethod()
-					.AllowCredentials();
-				});
+				options.AddDefaultPolicy(corsPolicy);
 			});
 
 
@@ -1138,35 +1238,6 @@ namespace GenOnlineService
 				}
 			}
 
-			var kestrelSettings = Program.g_Config.GetSection("Kestrel");
-			var endpointSettings = kestrelSettings.GetSection("Endpoints");
-			var httpsSettings = endpointSettings.GetSection("HTTPS");
-			string? serverURI = httpsSettings.GetValue<string>("Url");
-
-			if (serverURI == null)
-			{
-				Console.WriteLine("FATAL ERROR: serverURI is not set in the config");
-				Console.ReadKey(true);
-				return;
-			}
-
-			// Parse the port number out of serverURI
-			int port = -1;
-			try
-			{
-				if (!string.IsNullOrEmpty(serverURI))
-				{
-					var uri = new Uri(serverURI);
-					port = uri.Port;
-				}
-			}
-			catch
-			{
-				Console.WriteLine("ERROR: Failed to parse port from serverURI: " + serverURI);
-			}
-
-
-
 			// options
 			builder.WebHost.ConfigureKestrel(options =>
 			{
@@ -1195,6 +1266,12 @@ namespace GenOnlineService
 			var app = builder.Build();
 			ServiceLocator.Services = app.Services;
 
+			if (useForwardedHeaders)
+			{
+				// Must run before anything that consumes client IP or request scheme.
+				app.UseForwardedHeaders();
+			}
+
 			if (bUseBuiltinRateLimiter)
 			{
 				app.UseRateLimiter();
@@ -1211,6 +1288,21 @@ namespace GenOnlineService
 			};
 
 			app.UseWebSockets(webSocketOptions);
+
+			// WebSockets do not use CORS, so apply the same origin policy to browser
+			// handshakes explicitly. Native clients may omit Origin.
+			app.Use(async (context, next) =>
+			{
+				if (context.WebSockets.IsWebSocketRequest
+					&& context.Request.Headers.TryGetValue("Origin", out var originHeaders)
+					&& (originHeaders.Count != 1 || !corsPolicy.IsOriginAllowed(originHeaders[0]!)))
+				{
+					context.Response.StatusCode = StatusCodes.Status403Forbidden;
+					return;
+				}
+
+				await next(context);
+			});
 
 			// end websocket
 
@@ -1235,8 +1327,7 @@ namespace GenOnlineService
 			{
 				app.UseHsts();
 
-				// Websocket upgrades are exempt: ws_address_insecure is an intentional fallback for
-				// clients that can't do TLS, and redirecting the upgrade request would break it.
+				// WebSocket upgrades are exempt because redirecting an upgrade request breaks the handshake.
 				app.UseWhen(context => !context.WebSockets.IsWebSocketRequest, branch =>
 				{
 					branch.UseHttpsRedirection();

--- a/GenOnlineService/appsettings.json
+++ b/GenOnlineService/appsettings.json
@@ -19,6 +19,8 @@
     }
   },
   "AllowedHosts": "*",
+  "AllowedOrigins": [],
+  "TrustedProxies": [],
   "JwtSettings": {
     "Key": "TODO_CHANGE_ME",
     "Issuer": "YourIssuer",
@@ -27,8 +29,6 @@
     "ExpiresInMinutes_Refresh": 43200
   },
   "Core": {
-    "ws_address": "wss://127.0.0.1:9000/ws",
-    "ws_address_insecure": "ws://127.0.0.1:9000/ws",
     "use_os_cert_store": true,
     "cert_pem_path": null,
     "cert_key_path": null,


### PR DESCRIPTION
Adds optional reverse-proxy support while preserving direct hosting. Existing Kestrel HTTP/HTTPS endpoints and certificate handling remain supported and unchanged.

When `TrustedProxies` is empty, forwarded headers are ignored and Services continues using the connection’s direct client IP, scheme, and host.

---

When enabled, trusted proxies may provide:

- `X-Forwarded-For` for the original client IP
- `X-Forwarded-Proto` for the public scheme
- `X-Forwarded-Host` for the public host and port
- `X-Forwarded-Prefix` for a public path prefix

Trusted proxies can be configured using individual IPv4/IPv6 addresses and CIDR networks:

```json
"TrustedProxies": [
  "10.0.0.10",
  "10.20.0.0/16",
  "2001:db8:1234::/48"
]
```

`"*"` trusts forwarded headers from every sender. It is exclusive and cannot be combined with IP addresses or CIDR networks:

```json
"TrustedProxies": ["*"]
```

This should only be used when Services is network-isolated and reachable exclusively through the reverse proxy.

---

WebSocket URLs are derived from the effective request instead of hardcoded addresses. Direct HTTP and HTTPS continue producing `ws://` and `wss://` URLs respectively.

For example, a proxied request to `https://api.playgenerals.online` produces `wss://api.playgenerals.online/ws`.

---

`AllowedOrigins` configures which browser origins may use the HTTP API and WebSocket endpoint:

```json
"AllowedOrigins": [
  "https://admin.playgenerals.online",
  "https://*.playgenerals.online"
]
```

Explicit origins support credentials and wildcard subdomains.

`"*"` allows every origin without credentials. It is exclusive and cannot be combined with explicit origins:

```json
"AllowedOrigins": ["*"]
```

An empty list denies browser-origin access. Native clients (e.g. game clients) that omit the `Origin` header remain supported.

---

The HTTPS Kestrel endpoint is no longer mandatory. Deployments may continue serving HTTPS directly or optionally run HTTP-only behind a TLS-terminating proxy.
