### PR TITLE
feat(moderation): (3) accept client moderation commands

### DIFF
--- a/GenOnlineService/Constants.cs
+++ b/GenOnlineService/Constants.cs
@@ -846,6 +846,8 @@ namespace GenOnlineService
 	public class SharedUserData
 	{
 		private int m_RefCount = 0;
+		private readonly Queue<Int64> m_chatMessageTimestamps = new();
+		private Int64? m_lastChatRateLimitNoticeTimestamp;
 
 		public void IncrementRefCount()
 		{
@@ -874,6 +876,48 @@ namespace GenOnlineService
 		public UserSocialContainer GetSocialContainer() { return m_socialContainer; }
 
 		public bool IsAdmin() { return m_bIsAdmin; }
+
+		public bool TryConsumeChatMessage()
+		{
+			const int maxMessages = 3;
+			const Int64 windowMilliseconds = 9000;
+			Int64 now = Environment.TickCount64;
+
+			lock (m_chatMessageTimestamps)
+			{
+				while (m_chatMessageTimestamps.TryPeek(out Int64 timestamp)
+					&& now - timestamp >= windowMilliseconds)
+				{
+					m_chatMessageTimestamps.Dequeue();
+				}
+
+				if (m_chatMessageTimestamps.Count >= maxMessages)
+				{
+					return false;
+				}
+
+				m_chatMessageTimestamps.Enqueue(now);
+				return true;
+			}
+		}
+
+		public bool TryConsumeChatRateLimitNotice()
+		{
+			const Int64 intervalMilliseconds = 9000;
+			Int64 now = Environment.TickCount64;
+
+			lock (m_chatMessageTimestamps)
+			{
+				if (m_lastChatRateLimitNoticeTimestamp.HasValue
+					&& now - m_lastChatRateLimitNoticeTimestamp.Value < intervalMilliseconds)
+				{
+					return false;
+				}
+
+				m_lastChatRateLimitNoticeTimestamp = now;
+				return true;
+			}
+		}
 
 		public SharedUserData(Int64 ownerID, UserSocialContainer socialContainer, string strDisplayName, bool bIsAdmin, PlayerStats userStats)
 		{

--- a/GenOnlineService/Constants.cs
+++ b/GenOnlineService/Constants.cs
@@ -658,6 +658,30 @@ namespace GenOnlineService
 			return lstRet;
 		}
 
+		public static async Task DisconnectUser(Int64 userID, byte[] finalMessage)
+		{
+			List<UserSession> userSessions = GetAllDataFromUser(userID);
+
+			foreach (UserSession userSession in userSessions)
+			{
+				try
+				{
+					UserWebSocketInstance? oldWS = GetWebSocketForSession(userSession);
+					if (oldWS != null)
+					{
+						await oldWS.SendAsync(finalMessage, WebSocketMessageType.Text);
+					}
+
+					await DeleteSession(userID, userSession.GetSessionType(), oldWS, true);
+				}
+				catch (Exception ex)
+				{
+					Console.WriteLine($"[ERROR] DisconnectUser failed for user {userID}, session {userSession.GetSessionType()}: {ex.Message}");
+					SentrySdk.CaptureException(ex);
+				}
+			}
+		}
+
 		public static async Task<bool> ClearDataFromUser(Int64 userID, EUserSessionType sessionType)
 		{
 			// NOTE: This is when a player is truly disconnected and we can destroy session, remove form lobby etc, websocket disconnect doesnt mean that because the clietn reconnects
@@ -2545,7 +2569,10 @@ namespace GenOnlineService
 		AC_REGISTER_PLAYER = 40,
 		AC_DEREGISTER_PLAYER = 41,
 		WS_KEEPALIVE = 42,
-		WS_KEEPALIVE_CLIENT = 43
+		WS_KEEPALIVE_CLIENT = 43,
+		MODERATION_NOTICE = 46,
+		MODERATION_COMMAND = 47,
+		MODERATION_COMMAND_RESULT = 48
 	};
 
 	public static class UserPresence
@@ -2641,6 +2668,34 @@ namespace GenOnlineService
 	public class WebSocketMessage_StartMatch : WebSocketMessage
 	{
 		public string screenshot_url { get; set; } = String.Empty;
+	}
+
+	public class WebSocketMessage_ModerationNotice : WebSocketMessage
+	{
+		public string action_type { get; set; } = String.Empty;
+		public string reason { get; set; } = String.Empty;
+
+		[System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+		public string? scope_type { get; set; }
+	}
+
+	public sealed class WebSocketMessage_ModerationCommand : WebSocketMessage
+	{
+		public UInt64 request_id { get; set; }
+		public string action_type { get; set; } = String.Empty;
+		public Int64? target_user_id { get; set; }
+		public string reason { get; set; } = String.Empty;
+	}
+
+	public sealed class WebSocketMessage_ModerationCommandResult : WebSocketMessage
+	{
+		public UInt64 request_id { get; set; }
+		public bool success { get; set; }
+
+		[System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+		public string? error_code { get; set; }
+
+		public string message { get; set; } = String.Empty;
 	}
 
 	public abstract class WebSocketMessage

--- a/GenOnlineService/Controllers/CheckLogin/CheckLoginController.cs
+++ b/GenOnlineService/Controllers/CheckLogin/CheckLoginController.cs
@@ -41,6 +41,7 @@ namespace GenOnlineService.Controllers
 		public string refresh_token { get; set; } = "";
 		public Int64 user_id { get; set; } = -1;
 		public string display_name { get; set; } = "";
+		public string ban_reason { get; set; } = "";
 
 		public string ws_uri { get; set; } = "";
 	}
@@ -176,12 +177,14 @@ namespace GenOnlineService.Controllers
 										Int64 user_id = loginEntry.user_id;
 
 										// ban check
-										bool bIsBanned = await Database.Users.IsUserBanned(db, user_id);
-										if (bIsBanned)
+										UserBanStatus? banStatus = await Database.Users.GetUserBanStatus(db, user_id);
+										if (banStatus?.IsBanned == true)
 										{
 											await TokenRevocationManager.RevokeAllTokensForUser(user_id, "user is banned");
+											await ModerationManager.DisconnectUser(user_id, EModerationAction.Ban, banStatus.BanReason);
 
 											result.result = EPendingLoginState.LoginFailed;
+											result.ban_reason = banStatus.BanReason;
 											Response.StatusCode = (int)HttpStatusCode.Locked;
 											return result;
 										}

--- a/GenOnlineService/Controllers/LoginWithToken/LoginWithTokenController.cs
+++ b/GenOnlineService/Controllers/LoginWithToken/LoginWithTokenController.cs
@@ -41,6 +41,7 @@ namespace GenOnlineService.Controllers.LoginWithToken
 		public string refresh_token { get; set; } = "";
 		public Int64 user_id { get; set; } = -1;
 		public string display_name { get; set; } = "";
+		public string ban_reason { get; set; } = "";
 
 		public string ws_uri { get; set; } = "";
 	}
@@ -129,13 +130,15 @@ namespace GenOnlineService.Controllers.LoginWithToken
 						}
 
 						// ban check
-						bool bIsBanned = await Database.Users.IsUserBanned(db, user_id);
-						if (bIsBanned)
+						UserBanStatus? banStatus = await Database.Users.GetUserBanStatus(db, user_id);
+						if (banStatus?.IsBanned == true)
 						{
 							// kill every token they hold, not just this request
 							await TokenRevocationManager.RevokeAllTokensForUser(user_id, "user is banned");
+							await ModerationManager.DisconnectUser(user_id, EModerationAction.Ban, banStatus.BanReason);
 
 							result.result = EPendingLoginState.LoginFailed;
+							result.ban_reason = banStatus.BanReason;
 							Response.StatusCode = (int)HttpStatusCode.Locked;
 							return result;
 						}

--- a/GenOnlineService/Controllers/RefreshToken/RefreshTokenController.cs
+++ b/GenOnlineService/Controllers/RefreshToken/RefreshTokenController.cs
@@ -35,6 +35,7 @@ namespace GenOnlineService.Controllers.RefreshToken
 		public string refresh_token { get; set; } = "";
 		public Int64 user_id { get; set; } = -1;
 		public string display_name { get; set; } = "";
+		public string ban_reason { get; set; } = "";
 	}
 
 	// Pure token rotation. Unlike LoginWithToken this does NOT establish a session - the caller's
@@ -97,13 +98,15 @@ namespace GenOnlineService.Controllers.RefreshToken
 
 				// re-check the ban on every rotation so a ban applied since the last refresh takes
 				// effect immediately rather than waiting for the periodic reconcile
-				bool bIsBanned = await Database.Users.IsUserBanned(db, user_id);
-				if (bIsBanned)
+				UserBanStatus? banStatus = await Database.Users.GetUserBanStatus(db, user_id);
+				if (banStatus?.IsBanned == true)
 				{
 					// kill every token they hold, not just this request
 					await TokenRevocationManager.RevokeAllTokensForUser(user_id, "user is banned");
+					await ModerationManager.DisconnectUser(user_id, EModerationAction.Ban, banStatus.BanReason);
 
 					result.result = EPendingLoginState.LoginFailed;
+					result.ban_reason = banStatus.BanReason;
 					Response.StatusCode = (int)HttpStatusCode.Locked;
 					return result;
 				}

--- a/GenOnlineService/Controllers/Rooms/RoomsController.cs
+++ b/GenOnlineService/Controllers/Rooms/RoomsController.cs
@@ -33,6 +33,7 @@ namespace GenOnlineService.Controllers
 		}
 
 		public List<RoomData>? rooms { get; set; } = null;
+		public bool supports_moderation_commands { get; set; } = true;
 	}
 
 	[ApiController]

--- a/GenOnlineService/Controllers/WebSocket/WebSocketController.cs
+++ b/GenOnlineService/Controllers/WebSocket/WebSocketController.cs
@@ -47,6 +47,23 @@ namespace GenOnlineService.Controllers
 			AllowOutOfOrderMetadataProperties = true
 		};
 
+		private static void QueueChatRateLimited(UserSession session, SharedUserData userData, string scopeType)
+		{
+			if (!userData.TryConsumeChatRateLimitNotice())
+			{
+				return;
+			}
+
+			WebSocketMessage_ModerationNotice message = new()
+			{
+				msg_id = (int)EWebSocketMessageID.MODERATION_NOTICE,
+				action_type = "rate_limit",
+				reason = "Rate limit: Please wait before sending another message.",
+				scope_type = scopeType
+			};
+			session.QueueWebsocketSend(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(message)));
+		}
+
 		// GeoIP DB is designed to be reused; opening per request is expensive.
 		// It is gitignored and absent in fresh clones, so a failure to open must
 		// fall back to the lookup defaults rather than fail static init.
@@ -377,6 +394,22 @@ namespace GenOnlineService.Controllers
 
 					if (chatMessage != null)
 					{
+						if (!sourceUserData.TryConsumeChatMessage())
+						{
+							if (sourceUserData.TryConsumeChatRateLimitNotice())
+							{
+								WebSocketMessage_Social_FriendChatMessage_Outbound rateLimitMessage = new()
+								{
+									msg_id = (int)EWebSocketMessageID.SOCIAL_FRIEND_CHAT_MESSAGE_SERVER_TO_CLIENT,
+									source_user_id = sourceUserSession.m_UserID,
+									target_user_id = chatMessage.target_user_id,
+									message = "Rate limit: Please wait before sending another message."
+								};
+								sourceUserSession.QueueWebsocketSend(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(rateLimitMessage)));
+							}
+							return;
+						}
+
 						// must be online & friends
 
 						SharedUserData? targetUserData = WebSocketManager.GetSharedDataForUser(chatMessage.target_user_id);
@@ -428,6 +461,12 @@ namespace GenOnlineService.Controllers
 
 					if (chatMessage != null)
 					{
+						if (!sourceUserData.TryConsumeChatMessage())
+						{
+							QueueChatRateLimited(sourceUserSession, sourceUserData, "room");
+							return;
+						}
+
 						// response
 						WebSocketMessage_NetworkRoomChatMessageOutbound outboundMsg = new WebSocketMessage_NetworkRoomChatMessageOutbound();
 						outboundMsg.msg_id = (int)EWebSocketMessageID.NETWORK_ROOM_CHAT_FROM_SERVER;
@@ -705,6 +744,12 @@ namespace GenOnlineService.Controllers
 
 					if (chatMessage != null)
 					{
+						if (!sourceUserData.TryConsumeChatMessage())
+						{
+							QueueChatRateLimited(sourceUserSession, sourceUserData, "lobby");
+							return;
+						}
+
 						// get lobby
 						Lobby? playerLobby = _lobbyManager.GetLobby(sourceUserSession.currentLobbyID);
 

--- a/GenOnlineService/Controllers/WebSocket/WebSocketController.cs
+++ b/GenOnlineService/Controllers/WebSocket/WebSocketController.cs
@@ -64,6 +64,75 @@ namespace GenOnlineService.Controllers
 			session.QueueWebsocketSend(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(message)));
 		}
 
+		private static void QueueModerationCommandResult(
+			UserSession session,
+			UInt64 requestID,
+			bool success,
+			string message,
+			string? errorCode = null)
+		{
+			WebSocketMessage_ModerationCommandResult result = new()
+			{
+				msg_id = (int)EWebSocketMessageID.MODERATION_COMMAND_RESULT,
+				request_id = requestID,
+				success = success,
+				error_code = errorCode,
+				message = message
+			};
+			session.QueueWebsocketSend(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(result)));
+		}
+
+		private async Task ProcessModerationCommand(
+			byte[] payload,
+			UserSession session,
+			SharedUserData userData)
+		{
+			WebSocketMessage_ModerationCommand? command =
+				JsonSerializer.Deserialize<WebSocketMessage_ModerationCommand>(payload, JsonOpts);
+			if (command == null)
+			{
+				return;
+			}
+
+			if (!userData.IsAdmin())
+			{
+				QueueModerationCommandResult(session, command.request_id, false,
+					"You are not allowed to perform moderation actions.", "forbidden");
+				return;
+			}
+
+			if (command.action_type == "kick")
+			{
+				if (!command.target_user_id.HasValue || command.target_user_id.Value == session.m_UserID)
+				{
+					QueueModerationCommandResult(session, command.request_id, false,
+						"Select another online player to kick.", "invalid_target");
+					return;
+				}
+
+				ModerationResult kickResult = await ModerationManager.KickUser(command.target_user_id.Value, command.reason);
+				switch (kickResult.Result)
+				{
+					case EModerationResult.Success:
+						QueueModerationCommandResult(session, command.request_id, true,
+							$"{kickResult.TargetDisplayName} was kicked.");
+						break;
+					case EModerationResult.TargetNotOnline:
+						QueueModerationCommandResult(session, command.request_id, false,
+							"That player is no longer online.", "target_not_online");
+						break;
+					case EModerationResult.ReasonTooLong:
+						QueueModerationCommandResult(session, command.request_id, false,
+							$"The reason must be {ModerationManager.MaximumReasonLength} characters or fewer.", "reason_too_long");
+						break;
+				}
+				return;
+			}
+
+			QueueModerationCommandResult(session, command.request_id, false,
+				"That moderation action is not supported.", "unsupported_action");
+		}
+
 		// GeoIP DB is designed to be reused; opening per request is expensive.
 		// It is gitignored and absent in fresh clones, so a failure to open must
 		// fall back to the lookup defaults rather than fail static init.
@@ -386,6 +455,10 @@ namespace GenOnlineService.Controllers
 				else if (msgID == EWebSocketMessageID.SOCIAL_UNSUBSCRIBE_REALTIME_UPDATES)
 				{
 					sourceUserSession.SetSubscribedToRealtimeSocialUpdates(false);
+				}
+				else if (msgID == EWebSocketMessageID.MODERATION_COMMAND)
+				{
+					await ProcessModerationCommand(payload.ToArray(), sourceUserSession, sourceUserData);
 				}
 				else if (msgID == EWebSocketMessageID.SOCIAL_FRIEND_CHAT_MESSAGE_CLIENT_TO_SERVER)
 				{

--- a/GenOnlineService/Controllers/WebSocket/WebSocketController.cs
+++ b/GenOnlineService/Controllers/WebSocket/WebSocketController.cs
@@ -481,7 +481,7 @@ namespace GenOnlineService.Controllers
 						{
 							if (sourceUserData.IsAdmin())
 							{
-								outboundMsg.message = String.Format("[\u2605\u2605GO STAFF\u2605\u2605]    [{0}] {1}", sourceUserData.m_strDisplayName, chatMessage.message);
+								outboundMsg.message = String.Format("[\u2605\u2605GO STAFF\u2605\u2605] [{0}] {1}", sourceUserData.m_strDisplayName, chatMessage.message);
 								outboundMsg.admin = true;
 								outboundMsg.name_change = false;
 							}

--- a/GenOnlineService/Database/Database.User.cs
+++ b/GenOnlineService/Database/Database.User.cs
@@ -98,6 +98,12 @@ public class UserLobbyPreferences
 	public bool favorite_limit_superweapons = false;
 }
 
+public sealed class UserBanStatus
+{
+	public bool IsBanned { get; set; }
+	public string BanReason { get; set; } = String.Empty;
+}
+
 // TODO_EFCORE: add index for code
 public class PendingLoginConfiguration : IEntityTypeConfiguration<PendingLogin>
 {
@@ -279,6 +285,18 @@ namespace Database
 				  .Select(u => u.IsBanned)
 				  .FirstOrDefault());
 
+		private static readonly Func<AppDbContext, long, Task<UserBanStatus?>> _getUserBanStatusQuery =
+			EF.CompileAsyncQuery((AppDbContext db, long userId) =>
+				db.Users
+				  .AsNoTracking()
+				  .Where(u => u.ID == userId)
+				  .Select(u => new UserBanStatus
+				  {
+					  IsBanned = u.IsBanned,
+					  BanReason = u.BanReason ?? String.Empty
+				  })
+				  .FirstOrDefault());
+
 		private static readonly Func<AppDbContext, long, Task<string?>> _getDisplayNameQuery =
 				EF.CompileAsyncQuery((AppDbContext db, long userId) =>
 					db.Users
@@ -443,6 +461,20 @@ namespace Database
 				Console.WriteLine($"[ERROR] IsUserBanned failed: {ex.Message}");
 				SentrySdk.CaptureException(ex);
 				return false;
+			}
+		}
+
+		public static async Task<UserBanStatus?> GetUserBanStatus(AppDbContext db, long userId)
+		{
+			try
+			{
+				return await _getUserBanStatusQuery(db, userId);
+			}
+			catch (Exception ex)
+			{
+				Console.WriteLine($"[ERROR] GetUserBanStatus failed: {ex.Message}");
+				SentrySdk.CaptureException(ex);
+				return null;
 			}
 		}
 

--- a/GenOnlineService/Discord.cs
+++ b/GenOnlineService/Discord.cs
@@ -460,10 +460,9 @@ public class DiscordBot
 								}
 							}
 						}
-						else if (message.Content.ToLower().StartsWith("!kick"))
+						else if (message.Content.Equals("!kick", StringComparison.OrdinalIgnoreCase)
+							|| message.Content.StartsWith("!kick ", StringComparison.OrdinalIgnoreCase))
 						{
-							// TODO: In future we should validate users not just channels
-							// is it in the admin channel?
 							if (message.Channel.Id == g_dictChannelIDs[EDiscordChannelIDs.AdminCommands])
 							{
 								if (Program.g_Config == null)
@@ -471,60 +470,47 @@ public class DiscordBot
 									return;
 								}
 
-								// is it an admin?
-								IConfiguration? discordSettings = Program.g_Config.GetSection("Discord");
-
-								if (discordSettings == null)
+								List<UInt64>? discordAdmins = Program.g_Config
+									.GetSection("Discord")
+									.GetSection("discord_admins")
+									.Get<List<UInt64>>();
+								if (discordAdmins?.Contains(message.Author.Id) == true)
 								{
-									return;
-								}
-
-								List<UInt64>? discord_admins = discordSettings.GetSection("discord_admins").Get<List<UInt64>>();
-								if (discord_admins == null)
-								{
-									return;
-								}
-
-								if (discord_admins.Contains(message.Author.Id))
-								{
-									string[] strComponents = message.Content.Split(' ');
-									//var clients = message.Author.ActiveClients;
-
-									//var user = message.Author as IGuildUser; // Get the user from the command context
-									if (strComponents.Length == 2)
+									string[] strComponents = message.Content.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+									if (strComponents.Length >= 2)
 									{
-										string strUser = string.Join(' ', strComponents.Skip(1));
+										string strUser = strComponents[1];
 										if (Int64.TryParse(strUser, out Int64 TargetUserID))
 										{
-											SharedUserData? targetData = GenOnlineService.WebSocketManager.GetSharedDataForUser(TargetUserID);
-											
-											if (targetData != null)
-											{
-												PushChannelMessage(EDiscordChannelIDs.AdminCommands, $"User {TargetUserID} ({targetData.m_strDisplayName}) has been kicked from the server.");
+											string strReason = string.Join(' ', strComponents.Skip(2));
+											ModerationResult kickResult = await ModerationManager.KickUser(TargetUserID, strReason);
 
-												// we need to kill all websockets they have
-												List<UserSession> lstUserSessions = GenOnlineService.WebSocketManager.GetAllDataFromUser(TargetUserID);
-												foreach (UserSession userSession in lstUserSessions)
-												{
-													UserWebSocketInstance? oldWS = GenOnlineService.WebSocketManager.GetWebSocketForSession(userSession);
-													await GenOnlineService.WebSocketManager.DeleteSession(TargetUserID, userSession.GetSessionType(), oldWS, true);
-												}
-
-												
-											}
-											else
+											switch (kickResult.Result)
 											{
-												PushChannelMessage(EDiscordChannelIDs.AdminCommands, $"User {TargetUserID} is not active on the server.");
+												case EModerationResult.ReasonTooLong:
+													PushChannelMessage(EDiscordChannelIDs.AdminCommands, $"Kick reason must be {ModerationManager.MaximumReasonLength} characters or fewer.");
+													break;
+												case EModerationResult.TargetNotOnline:
+													PushChannelMessage(EDiscordChannelIDs.AdminCommands, $"User {TargetUserID} is not active on the server.");
+													break;
+												case EModerationResult.Success:
+													string confirmation = $"User {TargetUserID} ({kickResult.TargetDisplayName}) has been kicked from the server.";
+													if (!String.IsNullOrWhiteSpace(strReason))
+													{
+														confirmation += $" Reason: {strReason}";
+													}
+													PushChannelMessage(EDiscordChannelIDs.AdminCommands, confirmation);
+													break;
 											}
 										}
 										else
 										{
-											PushChannelMessage(EDiscordChannelIDs.AdminCommands, "Invalid Command Syntax. !kick <user_id> (e.g. !kick 123)");
+											PushChannelMessage(EDiscordChannelIDs.AdminCommands, "Invalid Command Syntax. !kick <user_id> [reason] (e.g. !kick 123 reconnect abuse)");
 										}
 									}
 									else
 									{
-										PushChannelMessage(EDiscordChannelIDs.AdminCommands, "Invalid Command Syntax. !kick <user_id> (e.g. !kick 123)");
+										PushChannelMessage(EDiscordChannelIDs.AdminCommands, "Invalid Command Syntax. !kick <user_id> [reason] (e.g. !kick 123 reconnect abuse)");
 									}
 								}
 								else

--- a/GenOnlineService/Moderation.cs
+++ b/GenOnlineService/Moderation.cs
@@ -1,0 +1,78 @@
+/*
+**    GeneralsOnline Game Services - Backend Services for Command & Conquer Generals Online: Zero Hour
+**    Copyright (C) 2025  GeneralsOnline Development Team
+**
+**    This program is free software: you can redistribute it and/or modify
+**    it under the terms of the GNU Affero General Public License as
+**    published by the Free Software Foundation, either version 3 of the
+**    License, or (at your option) any later version.
+*/
+
+using System.Text;
+using System.Text.Json;
+
+namespace GenOnlineService
+{
+	public enum EModerationResult
+	{
+		Success,
+		TargetNotOnline,
+		ReasonTooLong
+	}
+
+	public enum EModerationAction
+	{
+		Ban,
+		Kick
+	}
+
+	public sealed class ModerationResult
+	{
+		public EModerationResult Result { get; init; }
+		public string TargetDisplayName { get; init; } = String.Empty;
+	}
+
+	public static class ModerationManager
+	{
+		public const int MaximumReasonLength = 256;
+
+		public static async Task<ModerationResult> KickUser(Int64 targetUserID, string reason)
+		{
+			if (reason.Length > MaximumReasonLength)
+			{
+				return new ModerationResult { Result = EModerationResult.ReasonTooLong };
+			}
+
+			SharedUserData? target = WebSocketManager.GetSharedDataForUser(targetUserID);
+			if (target == null)
+			{
+				return new ModerationResult { Result = EModerationResult.TargetNotOnline };
+			}
+
+			await DisconnectUser(targetUserID, EModerationAction.Kick, reason);
+			return new ModerationResult
+			{
+				Result = EModerationResult.Success,
+				TargetDisplayName = target.m_strDisplayName
+			};
+		}
+
+		public static async Task DisconnectUser(Int64 userID, EModerationAction action, string? reason)
+		{
+			WebSocketMessage_ModerationNotice notice = new WebSocketMessage_ModerationNotice
+			{
+				msg_id = (int)EWebSocketMessageID.MODERATION_NOTICE,
+				action_type = action switch
+				{
+					EModerationAction.Ban => "ban",
+					EModerationAction.Kick => "kick",
+					_ => throw new ArgumentOutOfRangeException(nameof(action))
+				},
+				reason = reason ?? String.Empty
+			};
+			byte[] noticeJson = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(notice));
+
+			await WebSocketManager.DisconnectUser(userID, noticeJson);
+		}
+	}
+}

--- a/GenOnlineService/Program.cs
+++ b/GenOnlineService/Program.cs
@@ -409,6 +409,8 @@ namespace GenOnlineService
 
 	public class Program
 	{
+		private const string BannedUserContextKey = "GenOnlineService.BannedUserID";
+
 		public static IConfiguration? g_Config = null;
 		public static DiscordBot? g_Discord = null;
 
@@ -632,6 +634,7 @@ namespace GenOnlineService
 				// Revocation checks. All in-memory, no database access per request.
 				if (TokenRevocationManager.IsUserBanned(userID))
 				{
+					context.HttpContext.Items[BannedUserContextKey] = userID;
 					context.Fail("Failed Validation #12 - User is banned");
 					return Task.CompletedTask;
 				}
@@ -692,6 +695,28 @@ namespace GenOnlineService
 			}
 
 			return Task.CompletedTask;
+		}
+
+		private static async Task HandleJwtChallenge(JwtBearerChallengeContext context)
+		{
+			if (!context.HttpContext.Items.TryGetValue(BannedUserContextKey, out object? value)
+				|| value is not Int64 userID)
+			{
+				return;
+			}
+
+			IDbContextFactory<AppDbContext> dbFactory = context.HttpContext.RequestServices.GetRequiredService<IDbContextFactory<AppDbContext>>();
+			await using var db = await dbFactory.CreateDbContextAsync();
+			UserBanStatus? banStatus = await Database.Users.GetUserBanStatus(db, userID);
+
+			if (banStatus?.IsBanned != true)
+			{
+				return;
+			}
+
+			context.HandleResponse();
+			context.Response.StatusCode = StatusCodes.Status423Locked;
+			await context.Response.WriteAsJsonAsync(new { ban_reason = banStatus.BanReason });
 		}
 
 		public class JwtTokenGenerator
@@ -988,7 +1013,8 @@ namespace GenOnlineService
 
 				options.Events = new JwtBearerEvents
 				{
-					OnTokenValidated = AdditionalValidation
+					OnTokenValidated = AdditionalValidation,
+					OnChallenge = HandleJwtChallenge
 				};
 			}).AddScheme<AuthenticationSchemeOptions, BasicAuthenticationHandler>("Basic", null);
 
@@ -1404,9 +1430,9 @@ namespace GenOnlineService
 				timerTick.Start();
 			}
 
-			// keep token revocation state in sync with bans applied directly in the database
+			// Pick up bans applied directly in the database.
 			{
-				System.Timers.Timer timerTick = new System.Timers.Timer(60000); // 60s tick
+				System.Timers.Timer timerTick = new System.Timers.Timer(5000); // 5s tick
 				timerTick.AutoReset = false;
 				timerTick.Elapsed += async (sender, e) =>
 				{

--- a/GenOnlineService/TokenRevocation.cs
+++ b/GenOnlineService/TokenRevocation.cs
@@ -111,7 +111,7 @@ namespace Database
 			{
 				Console.WriteLine($"[ERROR] UserTokens.GetBannedUserIDs failed: {ex.Message}");
 				SentrySdk.CaptureException(ex);
-				return new List<Int64>();
+				throw;
 			}
 		}
 	}
@@ -244,8 +244,7 @@ namespace GenOnlineService
 			await Persist(userID, sessionType, newState);
 		}
 
-		// Invalidates every token previously issued to this user, across all session types, and drops
-		// any live websockets they hold.
+		// Invalidates every token previously issued to this user across all session types.
 		public static async Task RevokeAllTokensForUser(Int64 userID, string reason)
 		{
 			Console.WriteLine($"[TokenRevocation] Revoking all tokens for user {userID} ({reason}).");
@@ -260,7 +259,6 @@ namespace GenOnlineService
 				await Persist(userID, sessionType, newState);
 			}
 
-			await DisconnectUser(userID);
 		}
 
 		// Picks up bans applied directly in the database (there is no in-process ban API).
@@ -291,7 +289,9 @@ namespace GenOnlineService
 
 			foreach (Int64 userID in newlyBanned)
 			{
+				UserBanStatus? banStatus = await Database.Users.GetUserBanStatus(db, userID);
 				await RevokeAllTokensForUser(userID, "user was banned");
+				await ModerationManager.DisconnectUser(userID, EModerationAction.Ban, banStatus?.BanReason);
 			}
 		}
 
@@ -314,22 +314,5 @@ namespace GenOnlineService
 			}
 		}
 
-		private static async Task DisconnectUser(Int64 userID)
-		{
-			try
-			{
-				List<UserSession> lstUserSessions = WebSocketManager.GetAllDataFromUser(userID);
-				foreach (UserSession userSession in lstUserSessions)
-				{
-					UserWebSocketInstance? oldWS = WebSocketManager.GetWebSocketForSession(userSession);
-					await WebSocketManager.DeleteSession(userID, userSession.GetSessionType(), oldWS, true);
-				}
-			}
-			catch (Exception ex)
-			{
-				Console.WriteLine($"[ERROR] TokenRevocation.DisconnectUser failed: {ex.Message}");
-				SentrySdk.CaptureException(ex);
-			}
-		}
 	}
 }


### PR DESCRIPTION
Lets supported clients send moderation commands.
The server checks staff permission, handles kicks, and returns a clear result.